### PR TITLE
Add Lint to GitHub CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - run: yarn install
+    - run: yarn lint
     - run: yarn build
     - run: yarn test
       env: { CI: 1 }


### PR DESCRIPTION
We noticed that on Gitlab our CIs are failing due to lint errors.

We figured this is worth having on github actions