### PR TITLE
Looks for .app-config.meta files in workspace root if not in CWD

### DIFF
--- a/app-config/src/meta.test.ts
+++ b/app-config/src/meta.test.ts
@@ -1,3 +1,4 @@
+import { mkdirp } from 'fs-extra';
 import { FileType } from './config-source';
 import { loadMetaConfig } from './meta';
 import { withTempFiles } from './test-util';
@@ -23,6 +24,94 @@ describe('meta file loading', () => {
 
         expect(meta.value).toEqual({ foo: 'bar' });
         expect(meta.filePath).toBe(inDir('.app-config.meta.yml'));
+        expect(meta.fileType).toBe(FileType.YAML);
+      },
+    );
+  });
+
+  it('loads a meta file from the workspace root', async () => {
+    await withTempFiles(
+      {
+        '.app-config.meta.yml': `
+          foo: bar
+        `,
+      },
+      async (inDir) => {
+        await mkdirp(inDir('.git'));
+        await mkdirp(inDir('nested-folder/a/b/c'));
+
+        const meta = await loadMetaConfig({ directory: inDir('nested-folder/a/b/c') });
+
+        expect(meta.value).toEqual({ foo: 'bar' });
+        expect(meta.filePath).toBe(inDir('.app-config.meta.yml'));
+        expect(meta.fileType).toBe(FileType.YAML);
+      },
+    );
+  });
+
+  it('loads a meta file from a custom workspace root', async () => {
+    await withTempFiles(
+      {
+        '.app-config.meta.yml': `
+          foo: bar
+        `,
+      },
+      async (inDir) => {
+        await mkdirp(inDir('.svn'));
+        await mkdirp(inDir('nested-folder/a/b/c'));
+
+        const meta = await loadMetaConfig({
+          lookForWorkspace: '.svn',
+          directory: inDir('nested-folder/a/b/c'),
+        });
+
+        expect(meta.value).toEqual({ foo: 'bar' });
+        expect(meta.filePath).toBe(inDir('.app-config.meta.yml'));
+        expect(meta.fileType).toBe(FileType.YAML);
+      },
+    );
+  });
+
+  it('ignores meta file in workspace root when passed lookForWorkspace=false', async () => {
+    await withTempFiles(
+      {
+        '.app-config.meta.yml': `
+          foo: bar
+        `,
+      },
+      async (inDir) => {
+        await mkdirp(inDir('.git'));
+        await mkdirp(inDir('nested-folder/a/b/c'));
+
+        const meta = await loadMetaConfig({
+          lookForWorkspace: false,
+          directory: inDir('nested-folder/a/b/c'),
+        });
+
+        expect(meta.value).toEqual({});
+        expect(meta.filePath).toBeUndefined();
+        expect(meta.fileType).toBeUndefined();
+      },
+    );
+  });
+
+  it('loads a meta file from a nested folder in a workspace', async () => {
+    await withTempFiles(
+      {
+        '.app-config.meta.yml': `
+          foo: baz
+        `,
+        'a/b/c/.app-config.meta.yml': `
+          foo: bar
+        `,
+      },
+      async (inDir) => {
+        await mkdirp(inDir('.git'));
+
+        const meta = await loadMetaConfig({ directory: inDir('a/b/c') });
+
+        expect(meta.value).toEqual({ foo: 'bar' });
+        expect(meta.filePath).toBe(inDir('a/b/c/.app-config.meta.yml'));
         expect(meta.fileType).toBe(FileType.YAML);
       },
     );

--- a/app-config/src/meta.ts
+++ b/app-config/src/meta.ts
@@ -1,5 +1,6 @@
-import { join } from 'path';
-import { FlexibleFileSource, FileSource, FileType } from './config-source';
+import { join, resolve } from 'path';
+import { pathExists } from 'fs-extra';
+import { FlexibleFileSource, FileSource, FallbackSource, FileType } from './config-source';
 import { EncryptedSymmetricKey } from './encryption';
 import { NotFoundError } from './errors';
 import { GenerateFile } from './generate';
@@ -8,6 +9,7 @@ import { logger } from './logging';
 export interface Options {
   directory?: string;
   fileNameBase?: string;
+  lookForWorkspace?: string | false;
 }
 
 export interface TeamMember {
@@ -30,8 +32,35 @@ export interface MetaConfiguration {
 export async function loadMetaConfig({
   directory = '.',
   fileNameBase = '.app-config.meta',
+  lookForWorkspace = '.git',
 }: Options = {}): Promise<MetaConfiguration> {
-  const source = new FlexibleFileSource(join(directory, fileNameBase));
+  let workspaceRoot: string | undefined = resolve(directory);
+
+  // look upwards until a .git (workspace root) folder is found
+  while (lookForWorkspace) {
+    const parentDir = resolve(join(workspaceRoot, '..'));
+
+    // we didn't find a .git root
+    if (parentDir === workspaceRoot) {
+      workspaceRoot = undefined;
+      break;
+    }
+
+    workspaceRoot = parentDir;
+
+    if (await pathExists(join(workspaceRoot, lookForWorkspace))) {
+      break;
+    }
+  }
+
+  // we try to find meta find in our CWD, but fallback to the workspace (git repo) root
+  const sources = [new FlexibleFileSource(join(directory, fileNameBase))];
+
+  if (workspaceRoot) {
+    sources.push(new FlexibleFileSource(join(workspaceRoot, fileNameBase)));
+  }
+
+  const source = new FallbackSource(sources);
 
   try {
     const parsed = await source.read();


### PR DESCRIPTION
This fixes #25. I didn't want to make complicated semantics w/ merging of files or arbitrary positions (look up until one is found or something like that).