### PR TITLE
Passes environmentOverride and environmentAliases through into parsing extensions

### DIFF
--- a/app-config/src/config.ts
+++ b/app-config/src/config.ts
@@ -41,7 +41,7 @@ export async function loadConfig({
   extensionEnvironmentVariableNames = ['APP_CONFIG_EXTEND', 'APP_CONFIG_CI'],
   environmentOverride,
   environmentAliases = defaultAliases,
-  parsingExtensions = defaultExtensions,
+  parsingExtensions = defaultExtensions(environmentAliases, environmentOverride),
   secretsFileExtensions = parsingExtensions.concat(markAllValuesAsSecret),
   environmentExtensions = [],
 }: Options = {}): Promise<Configuration> {


### PR DESCRIPTION
This passes both options through into the parsing extensions, so that `$env` and `$substitute` use an override if it was provided. To avoid the "prop-drilling" type of thing here, we could have just set `process.env.APP_CONFIG_ENV`, but that has side effects (which would even break tests). Being explicit here isn't so bad, just a little more open to forgetfulness.