### PR TITLE
Passes loadConfig options through from Webpack plugin

### DIFF
--- a/app-config-webpack-plugin/src/index.ts
+++ b/app-config-webpack-plugin/src/index.ts
@@ -1,9 +1,9 @@
 import { join } from 'path';
 import { Compiler } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import type { ConfigLoadingOptions } from '@lcdev/app-config';
 import { regex } from './loader';
 import { loadConfig } from './compat';
-import type { ConfigLoadingOptions } from '@lcdev/app-config';
 
 // loader is the filepath, not the export
 const loader = require.resolve('./loader');

--- a/app-config-webpack-plugin/src/index.ts
+++ b/app-config-webpack-plugin/src/index.ts
@@ -3,17 +3,23 @@ import { Compiler } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { regex } from './loader';
 import { loadConfig } from './compat';
+import type { ConfigLoadingOptions } from '@lcdev/app-config';
 
 // loader is the filepath, not the export
 const loader = require.resolve('./loader');
 
-type Options = { headerInjection?: boolean };
+export interface Options {
+  headerInjection?: boolean;
+  loading?: ConfigLoadingOptions;
+}
 
 export default class AppConfigPlugin {
   headerInjection: boolean;
+  loadingOptions?: ConfigLoadingOptions;
 
-  constructor({ headerInjection = false }: Options = {}) {
+  constructor({ headerInjection = false, loading }: Options = {}) {
     this.headerInjection = headerInjection;
+    this.loadingOptions = loading;
   }
 
   static loader = loader;
@@ -35,7 +41,7 @@ export default class AppConfigPlugin {
           if (!resolve) return;
 
           if (resolve.request === '@lcdev/app-config' || resolve.request === 'app-config') {
-            const { filePaths } = await loadConfig();
+            const { filePaths } = await loadConfig(this.loadingOptions);
 
             if (filePaths?.length) {
               [resolve.request] = filePaths; // eslint-disable-line no-param-reassign
@@ -55,7 +61,7 @@ export default class AppConfigPlugin {
       HtmlWebpackPlugin.getHooks(compilation).alterAssetTagGroups.tapPromise(
         'AppConfigPlugin',
         async ({ headTags, ...html }) => {
-          const { fullConfig } = await loadConfig();
+          const { fullConfig } = await loadConfig(this.loadingOptions);
 
           // remove placeholder <script id="app-config"></script> if it exists
           const newTags = headTags.filter(({ attributes }) => attributes.id !== 'app-config');

--- a/app-config-webpack-plugin/src/loader.ts
+++ b/app-config-webpack-plugin/src/loader.ts
@@ -6,9 +6,9 @@ const loader: wp.loader.Loader = function AppConfigLoader() {
   if (this.cacheable) this.cacheable();
 
   const callback = this.async()!;
-  const { headerInjection = false } = getOptions(this) || {};
+  const { headerInjection = false, loading } = getOptions(this) || {};
 
-  loadConfig()
+  loadConfig(loading)
     .then(({ fullConfig, filePaths }) => {
       if (filePaths) {
         filePaths.forEach((filePath) => this.addDependency(filePath));

--- a/docs/guide/webpack/README.md
+++ b/docs/guide/webpack/README.md
@@ -65,3 +65,33 @@ short injection script that mutates the `index.html` with a new `<script id="app
 By doing that, the web app will have different configuration, without changing
 the JavaScript bundle at all. If you really wanted to, you could even change the
 HTML by hand.
+
+### Loading Options
+
+If you need to, you can pass options for the webpack plugin to use when loading app-config.
+
+```javascript
+// in your loaders:
+module: {
+  rules: [
+    {
+      test: AppConfigPlugin.regex,
+      use: {
+        loader: AppConfigPlugin.loader,
+        options: {
+          loading: {
+            // any options that are valid for loadConfig are valid here
+            directory: 'conf',
+            fileNameBase: '.my-config',
+          },
+        },
+      },
+    },
+  ],
+},
+
+// in your plugins:
+plugins: [
+  new AppConfigPlugin({ loading: { /* this should be the same as the loader */ } }),
+]
+```


### PR DESCRIPTION
Fixes #21.

Options for `loadConfig` are passed as the `loading` key in the plugin and loader.