### PR TITLE
Adds --environmentOverride CLI flag

### DIFF
--- a/app-config/src/__snapshots__/cli.test.ts.snap
+++ b/app-config/src/__snapshots__/cli.test.ts.snap
@@ -43,6 +43,10 @@ exports[`create prints simple app-config file 1`] = `
 "
 `;
 
+exports[`create uses environmentOverride option 1`] = `"APP_CONFIG_VAL=42"`;
+
+exports[`create uses environmentOverride option 2`] = `"APP_CONFIG_VAL=88"`;
+
 exports[`create uses fileNameBase option 1`] = `
 "foo: bar
 "

--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -151,6 +151,33 @@ describe('create', () => {
       },
     );
   });
+
+  it('uses environmentOverride option', async () => {
+    await withTempFiles(
+      {
+        '.app-config.yml': `
+          val:
+            $env:
+              default: 42
+              prod: 88
+        `,
+      },
+      async (inDir) => {
+        const { stdout: defaultValue } = await run(['vars', '-q', '-C', inDir('.')]);
+        expect(defaultValue).toMatchSnapshot();
+
+        const { stdout: production } = await run([
+          'vars',
+          '-q',
+          '-C',
+          inDir('.'),
+          '--environmentOverride=production',
+        ]);
+
+        expect(production).toMatchSnapshot();
+      },
+    );
+  });
 });
 
 describe('create-schema', () => {

--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -8,7 +8,12 @@ import { resolve, dereference } from 'json-schema-ref-parser';
 import { stripIndents } from 'common-tags';
 import { consumeStdin, flattenObjectTree, Json, JsonObject, promptUser } from './common';
 import { FileType, stringify } from './config-source';
-import { Configuration, loadConfig, loadValidatedConfig } from './config';
+import {
+  Configuration,
+  Options as LoadConfigOptions,
+  loadConfig,
+  loadValidatedConfig,
+} from './config';
 import {
   keyDirs,
   initializeLocalKeys,
@@ -111,6 +116,13 @@ const fileNameBaseOption = {
   group: OptionGroups.Options,
 } as const;
 
+const environmentOverrideOption = {
+  type: 'string',
+  description:
+    'Explicitly overrides the current environment (set by APP_CONFIG_ENV | NODE_ENV | ENV)',
+  group: OptionGroups.Options,
+} as const;
+
 const secretsOption = {
   alias: 's',
   type: 'boolean',
@@ -184,12 +196,15 @@ function fileTypeForFormatOption(option: string): FileType {
 function loadConfigWithOptions({
   noSchema,
   fileNameBase,
+  environmentOverride,
 }: {
   noSchema?: boolean;
   fileNameBase?: string;
+  environmentOverride?: string;
 }): ReturnType<typeof loadConfig> {
-  const options = {
+  const options: LoadConfigOptions = {
     fileNameBase,
+    environmentOverride,
   };
 
   if (noSchema) return loadConfig(options);
@@ -248,6 +263,7 @@ const { argv: _ } = yargs
           prefix: prefixOption,
           noSchema: noSchemaOption,
           fileNameBase: fileNameBaseOption,
+          environmentOverride: environmentOverrideOption,
           agent: secretAgentOption,
         },
       },
@@ -281,6 +297,7 @@ const { argv: _ } = yargs
           select: selectOption,
           noSchema: noSchemaOption,
           fileNameBase: fileNameBaseOption,
+          environmentOverride: environmentOverrideOption,
           agent: secretAgentOption,
         },
       },
@@ -725,6 +742,7 @@ const { argv: _ } = yargs
           select: selectOption,
           noSchema: noSchemaOption,
           fileNameBase: fileNameBaseOption,
+          environmentOverride: environmentOverrideOption,
           agent: secretAgentOption,
         },
       },


### PR DESCRIPTION
See #20 - adds Environment Override. This is a way to avoid setting APP_CONFIG_ENV, if someone really wanted to avoid it (maybe in a subshell where you can't set env vars).