### PR TITLE
Fixes secret-agent use in jest tests of consumers

### DIFF
--- a/app-config/src/encryption.ts
+++ b/app-config/src/encryption.ts
@@ -323,7 +323,8 @@ export async function encryptValue(
 
     try {
       client = await connectAgentLazy();
-    } catch {
+    } catch (err) {
+      logger.verbose(`Secret agent connect error: ${err.toString()}`);
       logger.warn('Secret agent is not running');
     }
 
@@ -374,7 +375,8 @@ export async function decryptValue(
 
     try {
       client = await connectAgentLazy();
-    } catch {
+    } catch (err) {
+      logger.verbose(`Secret agent connect error: ${err.toString()}`);
       logger.warn('Secret agent is not running');
     }
 

--- a/app-config/src/secret-agent-tls.ts
+++ b/app-config/src/secret-agent-tls.ts
@@ -90,17 +90,6 @@ export async function generateCert(): Promise<Cert> {
 }
 
 export async function loadOrCreateCert(): Promise<Cert> {
-  // we'll skip loading settings in jest-land
-  if (process.env.JEST_WORKER_ID !== undefined) {
-    const loaded = (global as unknown) as { secretAgentCert: Promise<Cert> };
-
-    if (!loaded.secretAgentCert) {
-      loaded.secretAgentCert = generateCert();
-    }
-
-    return loaded.secretAgentCert;
-  }
-
   const settings = await loadSettingsLazy();
 
   if (settings.secretAgent) {


### PR DESCRIPTION
Makes connection errors a bit more verbose so it's not a catch-all. TLS errors were being covered up before. The loadSettings call was stubbed in jest tests before because I didn't want to rely on a home folder in CI images, but it should be okay (they're empty and defaulted anyways). This still makes higher-level tests hard to stub in settings, but no tests like that exist right now.