### PR TITLE
Uses $extends and $override when loading meta files

### DIFF
--- a/app-config/src/meta.test.ts
+++ b/app-config/src/meta.test.ts
@@ -27,4 +27,48 @@ describe('meta file loading', () => {
       },
     );
   });
+
+  it('uses $extends in a meta file', async () => {
+    await withTempFiles(
+      {
+        '.app-config.meta.yml': `
+          foo: qux
+          $extends: ./other-file.yml
+        `,
+        'other-file.yml': `
+          foo: bar
+          bar: baz
+        `,
+      },
+      async (inDir) => {
+        const meta = await loadMetaConfig({ directory: inDir('.') });
+
+        expect(meta.value).toEqual({ foo: 'qux', bar: 'baz' });
+        expect(meta.filePath).toBe(inDir('.app-config.meta.yml'));
+        expect(meta.fileType).toBe(FileType.YAML);
+      },
+    );
+  });
+
+  it('uses $override in a meta file', async () => {
+    await withTempFiles(
+      {
+        '.app-config.meta.yml': `
+          foo: qux
+          $override: ./other-file.yml
+        `,
+        'other-file.yml': `
+          foo: bar
+          bar: baz
+        `,
+      },
+      async (inDir) => {
+        const meta = await loadMetaConfig({ directory: inDir('.') });
+
+        expect(meta.value).toEqual({ foo: 'bar', bar: 'baz' });
+        expect(meta.filePath).toBe(inDir('.app-config.meta.yml'));
+        expect(meta.fileType).toBe(FileType.YAML);
+      },
+    );
+  });
 });

--- a/app-config/src/meta.ts
+++ b/app-config/src/meta.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { FlexibleFileSource, FileSource, FileType } from './config-source';
+import { extendsDirective, overrideDirective } from './extensions';
 import { EncryptedSymmetricKey } from './encryption';
 import { NotFoundError } from './errors';
 import { GenerateFile } from './generate';
@@ -34,9 +35,11 @@ export async function loadMetaConfig({
   const source = new FlexibleFileSource(join(directory, fileNameBase));
 
   try {
-    const parsed = await source.read();
+    const parsed = await source.read([extendsDirective(), overrideDirective()]);
     const value = parsed.toJSON() as MetaProperties;
-    const { filePath, fileType } = parsed.assertSource(FileSource);
+
+    const fileSources = parsed.sources.filter((s) => s instanceof FileSource) as FileSource[];
+    const [{ filePath, fileType }] = fileSources.filter((s) => s.filePath.includes(fileNameBase));
 
     logger.verbose(`Meta file was loaded from ${filePath}`);
 


### PR DESCRIPTION
#26 has some discussion of this. Enables sharing meta config in a monorepo.