### PR TITLE
Reserve $-prefix object properties for future proofing, allow escaping with $$

### DIFF
--- a/app-config/src/errors.ts
+++ b/app-config/src/errors.ts
@@ -36,3 +36,6 @@ export class EncryptionEncoding extends AppConfigError {}
 
 /** Could not select a sub-object using a JSON pointer */
 export class FailedToSelectSubObject extends AppConfigError {}
+
+/** Found a key starting with $ in config object */
+export class ReservedKeyError extends AppConfigError {}

--- a/app-config/src/extensions.ts
+++ b/app-config/src/extensions.ts
@@ -2,12 +2,13 @@ import { join, dirname, extname, isAbsolute } from 'path';
 import { pathExists } from 'fs-extra';
 import { isObject, Json } from './common';
 import { currentEnvironment, defaultAliases, EnvironmentAliases } from './environment';
-import { ParsedValue, ParsedValueMetadata, ParsingExtension, Root } from './parsed-value';
+import { ParsedValue, ParsedValueMetadata, ParsingExtension, Root, InObject } from './parsed-value';
 import { FileSource } from './config-source';
 import { decryptValue, DecryptedSymmetricKey } from './encryption';
 import { AppConfigError, NotFoundError, FailedToSelectSubObject } from './errors';
 import { logger } from './logging';
 
+/** ParsingExtensions that are used by default in loadConfig for reading files */
 export function defaultExtensions(
   aliases: EnvironmentAliases = defaultAliases,
   environmentOverride?: string,
@@ -19,8 +20,14 @@ export function defaultExtensions(
     extendsDirective(),
     overrideDirective(),
     encryptedDirective(symmetricKey),
+    unescape$Directives(),
     environmentVariableSubstitution(aliases, environmentOverride),
   ];
+}
+
+/** ParsingExtensions that are used by default in loadConfig for APP_CONFIG variable */
+export function defaultEnvExtensions(): ParsingExtension[] {
+  return [unescape$Directives()];
 }
 
 /** Uses another file as a "base", and extends on top of it */
@@ -85,6 +92,19 @@ export function encryptedDirective(symmetricKey?: DecryptedSymmetricKey): Parsin
         const decrypted = await decryptValue(value, symmetricKey);
 
         return parse(decrypted, { fromSecrets: true, parsedFromEncryptedValue: true });
+      };
+    }
+
+    return false;
+  };
+}
+
+/** When a key $$foo is seen, change it to be $foo and mark with meta property fromEscapedDirective */
+export function unescape$Directives(): ParsingExtension {
+  return (value, [_, key]) => {
+    if (typeof key === 'string' && key.startsWith('$$')) {
+      return async (parse) => {
+        return parse(value, { rewriteKey: key.slice(1), fromEscapedDirective: true });
       };
     }
 

--- a/app-config/src/extensions.ts
+++ b/app-config/src/extensions.ts
@@ -2,7 +2,7 @@ import { join, dirname, extname, isAbsolute } from 'path';
 import { pathExists } from 'fs-extra';
 import { isObject, Json } from './common';
 import { currentEnvironment, defaultAliases, EnvironmentAliases } from './environment';
-import { ParsedValue, ParsedValueMetadata, ParsingExtension, Root, InObject } from './parsed-value';
+import { ParsedValue, ParsedValueMetadata, ParsingExtension, Root } from './parsed-value';
 import { FileSource } from './config-source';
 import { decryptValue, DecryptedSymmetricKey } from './encryption';
 import { AppConfigError, NotFoundError, FailedToSelectSubObject } from './errors';

--- a/app-config/src/parsed-value.ts
+++ b/app-config/src/parsed-value.ts
@@ -425,6 +425,10 @@ async function parseValueInner(
         } else if (parsed.meta.shouldOverride) {
           toOverride.push(parsed.removeMeta('shouldOverride'));
         } else if (parsed.meta.rewriteKey) {
+          if (typeof parsed.meta.rewriteKey !== 'string') {
+            throw new AppConfigError('Internal error: rewriteKey was not a string');
+          }
+
           obj[parsed.meta.rewriteKey] = parsed.removeMeta('rewriteKey');
         } else {
           obj[key] = parsed;

--- a/app-config/src/parsed-value.ts
+++ b/app-config/src/parsed-value.ts
@@ -424,6 +424,8 @@ async function parseValueInner(
           toMerge.push(parsed.removeMeta('shouldMerge'));
         } else if (parsed.meta.shouldOverride) {
           toOverride.push(parsed.removeMeta('shouldOverride'));
+        } else if (parsed.meta.rewriteKey) {
+          obj[parsed.meta.rewriteKey] = parsed.removeMeta('rewriteKey');
         } else {
           obj[key] = parsed;
         }


### PR DESCRIPTION
This is pretty much solely a warning / blocking mechanism to avoid causing ourselves trouble in the future (if we wanted to add a `$fetch`, for example). See #33.

Comes at an unfortunate cost (an extra visit on every object property), mostly as a consequence of separating parsing and config loading (adding a cheeky check somewhere else breaks the modularity).