### PR TITLE
Adds options for environment variables to filter and rename

### DIFF
--- a/app-config/src/__snapshots__/cli.test.ts.snap
+++ b/app-config/src/__snapshots__/cli.test.ts.snap
@@ -124,6 +124,11 @@ $schema: 'http://json-schema.org/draft-07/schema#'
 "
 `;
 
+exports[`vars aliases a variable 1`] = `
+"APP_CONFIG_FOO=true
+BAR=true"
+`;
+
 exports[`vars filters list of variables with --only 1`] = `"FOO=true"`;
 
 exports[`vars prints only nonSecrets without --secrets option 1`] = `"APP_CONFIG_NON_SECRET=true"`;

--- a/app-config/src/__snapshots__/cli.test.ts.snap
+++ b/app-config/src/__snapshots__/cli.test.ts.snap
@@ -124,6 +124,8 @@ $schema: 'http://json-schema.org/draft-07/schema#'
 "
 `;
 
+exports[`vars filters list of variables with --only 1`] = `"FOO=true"`;
+
 exports[`vars prints only nonSecrets without --secrets option 1`] = `"APP_CONFIG_NON_SECRET=true"`;
 
 exports[`vars prints only nonSecrets without --secrets option 2`] = `
@@ -132,5 +134,7 @@ APP_CONFIG_NON_SECRET=true"
 `;
 
 exports[`vars prints simple app-config file 1`] = `"APP_CONFIG_FOO=true"`;
+
+exports[`vars renames a variable 1`] = `"BAR=true"`;
 
 exports[`vars uses provided environment variable prefix 1`] = `"MY_CONFIG_FOO=true"`;

--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -31,7 +31,16 @@ describe('vars', () => {
 
   it('renames a variable', async () => {
     const APP_CONFIG = JSON.stringify({ foo: true });
-    const { stdout } = await run(['vars', '-q', '-r', 'APP_CONFIG_FOO=BAR'], {
+    const { stdout } = await run(['vars', '-q', '--rename', 'APP_CONFIG_FOO=BAR'], {
+      env: { APP_CONFIG },
+    });
+
+    expect(stdout).toMatchSnapshot();
+  });
+
+  it('aliases a variable', async () => {
+    const APP_CONFIG = JSON.stringify({ foo: true });
+    const { stdout } = await run(['vars', '-q', '--alias', 'APP_CONFIG_FOO=BAR'], {
       env: { APP_CONFIG },
     });
 

--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -29,6 +29,24 @@ describe('vars', () => {
     expect(stdout).toMatchSnapshot();
   });
 
+  it('renames a variable', async () => {
+    const APP_CONFIG = JSON.stringify({ foo: true });
+    const { stdout } = await run(['vars', '-q', '-r', 'APP_CONFIG_FOO=BAR'], {
+      env: { APP_CONFIG },
+    });
+
+    expect(stdout).toMatchSnapshot();
+  });
+
+  it('filters list of variables with --only', async () => {
+    const APP_CONFIG = JSON.stringify({ foo: true, bar: true });
+    const { stdout } = await run(['vars', '-q', '--prefix=""', '--only', 'FOO'], {
+      env: { APP_CONFIG },
+    });
+
+    expect(stdout).toMatchSnapshot();
+  });
+
   it('prints only nonSecrets without --secrets option', async () => {
     await withTempFiles(
       {

--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -6,7 +6,14 @@ import clipboardy from 'clipboardy';
 import { outputFile, readFile } from 'fs-extra';
 import { resolve, dereference } from 'json-schema-ref-parser';
 import { stripIndents } from 'common-tags';
-import { consumeStdin, flattenObjectTree, Json, JsonObject, promptUser } from './common';
+import {
+  promptUser,
+  consumeStdin,
+  flattenObjectTree,
+  renameInFlattenedTree,
+  Json,
+  JsonObject,
+} from './common';
 import { FileType, stringify } from './config-source';
 import {
   Configuration,
@@ -139,6 +146,21 @@ const prefixOption = {
   group: OptionGroups.Options,
 } as const;
 
+const renameVariablesOption = {
+  alias: 'r',
+  type: 'string',
+  array: true,
+  description: 'Renames environment variables (eg. HTTP_PORT=FOO)',
+  group: OptionGroups.Options,
+} as const;
+
+const onlyVariablesOption = {
+  type: 'string',
+  array: true,
+  description: 'Limits which environment variables are exported',
+  group: OptionGroups.Options,
+} as const;
+
 const environmentVariableNameOption = {
   type: 'string',
   default: 'APP_CONFIG',
@@ -174,14 +196,83 @@ const secretAgentOption = {
   group: OptionGroups.Options,
 } as const;
 
-function selectSecretsOrNot(config: Configuration, secrets: boolean): JsonObject {
-  const { fullConfig, parsedNonSecrets } = config;
+interface LoadConfigCLIOptions {
+  secrets?: boolean;
+  select?: string;
+  noSchema?: boolean;
+  fileNameBase?: string;
+  environmentOverride?: string;
+  environmentVariableName?: string;
+}
 
-  if (secrets || !parsedNonSecrets) {
-    return fullConfig as JsonObject;
+async function loadConfigWithOptions({
+  secrets: includeSecrets,
+  select,
+  noSchema,
+  fileNameBase,
+  environmentOverride,
+  environmentVariableName,
+}: LoadConfigCLIOptions): Promise<JsonObject> {
+  const options: LoadConfigOptions = {
+    fileNameBase,
+    environmentOverride,
+    environmentVariableName,
+  };
+
+  let loaded: Configuration;
+  if (noSchema) {
+    loaded = await loadConfig(options);
+  } else {
+    loaded = await loadValidatedConfig(options);
   }
 
-  return parsedNonSecrets.toJSON() as JsonObject;
+  const { fullConfig, parsedNonSecrets } = loaded;
+
+  let jsonConfig: JsonObject;
+
+  if (includeSecrets || !parsedNonSecrets) {
+    jsonConfig = fullConfig as JsonObject;
+  } else {
+    jsonConfig = parsedNonSecrets.toJSON() as JsonObject;
+  }
+
+  if (select) {
+    jsonConfig = (await resolve(jsonConfig)).get(select) as JsonObject;
+
+    if (jsonConfig === undefined) {
+      throw new FailedToSelectSubObject(`Failed to select property ${select}`);
+    }
+  }
+
+  return jsonConfig;
+}
+
+async function loadVarsWithOptions({
+  prefix,
+  rename,
+  only,
+  ...opts
+}: LoadConfigCLIOptions & {
+  prefix: string;
+  rename?: string[];
+  only?: string[];
+}): Promise<[ReturnType<typeof flattenObjectTree>, JsonObject]> {
+  const config = await loadConfigWithOptions(opts);
+  const flattened = renameInFlattenedTree(flattenObjectTree(config, prefix), rename);
+
+  if (only) {
+    const filtered: typeof flattened = {};
+
+    for (const variable of Object.keys(flattened)) {
+      if (only.includes(variable)) {
+        filtered[variable] = flattened[variable];
+      }
+    }
+
+    return [filtered, config];
+  }
+
+  return [flattened, config];
 }
 
 function fileTypeForFormatOption(option: string): FileType {
@@ -198,27 +289,6 @@ function fileTypeForFormatOption(option: string): FileType {
     default:
       throw new AppConfigError(`${option} is not a valid file type`);
   }
-}
-
-function loadConfigWithOptions({
-  noSchema,
-  fileNameBase,
-  environmentOverride,
-  environmentVariableName,
-}: {
-  noSchema?: boolean;
-  fileNameBase?: string;
-  environmentOverride?: string;
-  environmentVariableName?: string;
-}): ReturnType<typeof loadConfig> {
-  const options: LoadConfigOptions = {
-    fileNameBase,
-    environmentOverride,
-    environmentVariableName,
-  };
-
-  if (noSchema) return loadConfig(options);
-  return loadValidatedConfig(options);
 }
 
 export const cli = yargs
@@ -272,6 +342,9 @@ export const cli = yargs
         options: {
           secrets: secretsOption,
           prefix: prefixOption,
+          rename: renameVariablesOption,
+          only: onlyVariablesOption,
+          select: selectOption,
           noSchema: noSchemaOption,
           fileNameBase: fileNameBaseOption,
           environmentOverride: environmentOverrideOption,
@@ -282,10 +355,10 @@ export const cli = yargs
       async (opts) => {
         shouldUseSecretAgent(opts.agent);
 
-        const toPrint = selectSecretsOrNot(await loadConfigWithOptions(opts), opts.secrets);
+        const [env] = await loadVarsWithOptions(opts);
 
         process.stdout.write(
-          Object.entries(flattenObjectTree(toPrint, opts.prefix))
+          Object.entries(env)
             .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
             .join('\n'),
         );
@@ -317,15 +390,7 @@ export const cli = yargs
       async (opts) => {
         shouldUseSecretAgent(opts.agent);
 
-        let toPrint = selectSecretsOrNot(await loadConfigWithOptions(opts), opts.secrets);
-
-        if (opts.select) {
-          toPrint = (await resolve(toPrint)).get(opts.select) as JsonObject;
-
-          if (toPrint === undefined) {
-            throw new FailedToSelectSubObject(`Failed to select property ${opts.select}`);
-          }
-        }
+        const toPrint = await loadConfigWithOptions(opts);
 
         process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format)));
         process.stdout.write('\n');
@@ -751,6 +816,8 @@ export const cli = yargs
         options: {
           secrets: secretsOption,
           prefix: prefixOption,
+          rename: renameVariablesOption,
+          only: onlyVariablesOption,
           format: { ...formatOption, default: 'json' },
           select: selectOption,
           noSchema: noSchemaOption,
@@ -770,22 +837,20 @@ export const cli = yargs
           process.exit(1);
         }
 
-        let toPrint = selectSecretsOrNot(await loadConfigWithOptions(opts), opts.secrets);
+        const [env, fullConfig] = await loadVarsWithOptions(opts);
 
-        if (opts.select) {
-          toPrint = (await resolve(toPrint)).get(opts.select) as JsonObject;
-
-          if (toPrint === undefined) {
-            throw new FailedToSelectSubObject(`Failed to select property ${opts.select}`);
+        // if prefix is set to something non-zero, set it as the full config
+        // this is almost always just APP_CONFIG
+        if (opts.prefix.length > 0) {
+          // if we specified --only FOO, don't include APP_CONFIG
+          if (!opts.only || opts.only.includes(opts.prefix)) {
+            env[opts.prefix] = stringify(fullConfig, fileTypeForFormatOption(opts.format), true);
           }
         }
 
         await execa(command, args, {
           stdio: 'inherit',
-          env: {
-            [opts.prefix]: stringify(toPrint, fileTypeForFormatOption(opts.format), true),
-            ...flattenObjectTree(toPrint, opts.prefix),
-          },
+          env,
         }).catch((err) => {
           logger.error(err.message);
 

--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -154,6 +154,13 @@ const renameVariablesOption = {
   group: OptionGroups.Options,
 } as const;
 
+const aliasVariablesOption = {
+  type: 'string',
+  array: true,
+  description: 'Like --rename, but keeps original name in results',
+  group: OptionGroups.Options,
+} as const;
+
 const onlyVariablesOption = {
   type: 'string',
   array: true,
@@ -250,15 +257,20 @@ async function loadConfigWithOptions({
 async function loadVarsWithOptions({
   prefix,
   rename,
+  alias,
   only,
   ...opts
 }: LoadConfigCLIOptions & {
   prefix: string;
   rename?: string[];
+  alias?: string[];
   only?: string[];
 }): Promise<[ReturnType<typeof flattenObjectTree>, JsonObject]> {
   const config = await loadConfigWithOptions(opts);
-  const flattened = renameInFlattenedTree(flattenObjectTree(config, prefix), rename);
+  let flattened = flattenObjectTree(config, prefix);
+
+  flattened = renameInFlattenedTree(flattened, rename, false);
+  flattened = renameInFlattenedTree(flattened, alias, true);
 
   if (only) {
     const filtered: typeof flattened = {};
@@ -343,6 +355,7 @@ export const cli = yargs
           secrets: secretsOption,
           prefix: prefixOption,
           rename: renameVariablesOption,
+          alias: aliasVariablesOption,
           only: onlyVariablesOption,
           select: selectOption,
           noSchema: noSchemaOption,
@@ -817,6 +830,7 @@ export const cli = yargs
           secrets: secretsOption,
           prefix: prefixOption,
           rename: renameVariablesOption,
+          alias: aliasVariablesOption,
           only: onlyVariablesOption,
           format: { ...formatOption, default: 'json' },
           select: selectOption,

--- a/app-config/src/common.test.ts
+++ b/app-config/src/common.test.ts
@@ -1,4 +1,4 @@
-import { camelToScreamingCase, flattenObjectTree } from './common';
+import { camelToScreamingCase, flattenObjectTree, renameInFlattenedTree } from './common';
 
 describe('camelToScreamingCase', () => {
   it('converts a typical camel case name', () => {
@@ -142,6 +142,15 @@ describe('flattenObjectTree', () => {
 
     expect(flattenedObject).toMatchObject({
       UNICORN: undefined,
+    });
+  });
+});
+
+describe('renameInFlattenedTree', () => {
+  it('renames a property name', () => {
+    expect(renameInFlattenedTree({ FOO: 'value', BAZ: '42' }, ['FOO=BAR'])).toEqual({
+      BAR: 'value',
+      BAZ: '42',
     });
   });
 });

--- a/app-config/src/common.ts
+++ b/app-config/src/common.ts
@@ -1,6 +1,7 @@
 import readline from 'readline';
 import prompts from 'prompts';
 import type { PromptObject } from 'prompts';
+import { logger } from './logging';
 
 export type PromiseOrNot<T> = Promise<T> | T;
 
@@ -32,14 +33,14 @@ export function camelToScreamingCase(key: string, separator: string = '_'): stri
     .toUpperCase();
 }
 
-export const flattenObjectTree = (
+export function flattenObjectTree(
   obj: JsonObject,
   prefix: string = '',
   separator: string = '_',
   formatter: KeyFormatter = camelToScreamingCase,
-): { [key: string]: string } => {
+): { [key: string]: string } {
   return Object.entries(obj).reduce((merged, [key, value]) => {
-    const flatKey = `${prefix}${prefix && separator}${formatter(key, separator)}`;
+    const flatKey = `${prefix}${prefix ? separator : ''}${formatter(key, separator)}`;
 
     let flattenedObject;
 
@@ -59,7 +60,30 @@ export const flattenObjectTree = (
 
     return Object.assign(merged, flattenedObject);
   }, {});
-};
+}
+
+export function renameInFlattenedTree(
+  flattened: { [key: string]: string },
+  renames: string[] = [],
+): typeof flattened {
+  for (const rename of renames) {
+    const matched = /^(.*)=(.*)$/.exec(rename);
+
+    if (matched) {
+      const [, renameFrom, renameTo] = matched;
+      if (flattened[renameFrom]) {
+        flattened[renameTo] = flattened[renameFrom]; // eslint-disable-line no-param-reassign
+        delete flattened[renameFrom]; // eslint-disable-line no-param-reassign
+      } else {
+        logger.warn(`A rename was used ('${rename}'), but no value was found.`);
+      }
+    } else {
+      logger.warn(`A rename was used ('${rename}'), but not in correct format.`);
+    }
+  }
+
+  return flattened;
+}
 
 export async function promptUser<T>(options: Omit<PromptObject, 'name'>): Promise<T> {
   const { named } = await prompts({ ...options, name: 'named' });

--- a/app-config/src/common.ts
+++ b/app-config/src/common.ts
@@ -65,6 +65,7 @@ export function flattenObjectTree(
 export function renameInFlattenedTree(
   flattened: { [key: string]: string },
   renames: string[] = [],
+  keepOriginalKeys = false,
 ): typeof flattened {
   for (const rename of renames) {
     const matched = /^(.*)=(.*)$/.exec(rename);
@@ -73,7 +74,10 @@ export function renameInFlattenedTree(
       const [, renameFrom, renameTo] = matched;
       if (flattened[renameFrom]) {
         flattened[renameTo] = flattened[renameFrom]; // eslint-disable-line no-param-reassign
-        delete flattened[renameFrom]; // eslint-disable-line no-param-reassign
+
+        if (!keepOriginalKeys) {
+          delete flattened[renameFrom]; // eslint-disable-line no-param-reassign
+        }
       } else {
         logger.warn(`A rename was used ('${rename}'), but no value was found.`);
       }


### PR DESCRIPTION
This adds two options to the CLI:
- `--only`: Filters environment variables exclusively
- `--rename`: Changes the environment variable names one-by-one
- `--alias`: Aliases environment variable names one-by-one, retaining the initial name

These apply to the `app-config vars` and `app-config -- env` subcommands. At the moment, our docs don't go into CLI flags much at all. I'd probably like to tackle that separately.

Alongside this change, I've refactored the CLI functions to share more logic (--select, flattened vars, etc).

### Motivation:
This is generally useful, but it also has specific use cases. The one I ran into was with [hasura](https://hasura.io), which expects a `HASURA_GRAPHQL_ADMIN_SECRET` environment variable. Naturally, I didn't want to change the object structure of app-config simply to appease the environment variable name format. So, a `--rename APP_CONFIG_HASURA_SECRET=HASURA_GRAPHQL_ADMIN_SECRET` felt like a natural "translation" for this. Alongside this, of course, is `--only`. Very often, there are many secrets that fall into different subsections of an app. I don't need Hasura to see Grafana secrets, for example.

More generally, for app-config to call itself general purpose, I think it needs to have these types of features in order to replace `.env`.