### PR TITLE
Adds a special `$self` referencing directive, copying values within the same file

### DIFF
--- a/app-config/src/extensions.test.ts
+++ b/app-config/src/extensions.test.ts
@@ -386,6 +386,30 @@ describe('$extendsSelf directive', () => {
       qux: 42,
     });
   });
+
+  it.only('resolves an $extends selector to own file', async () => {
+    await withTempFiles(
+      {
+        'test-file.yaml': `
+          foo:
+            bar:
+              baz: 42
+
+          qux:
+            $extends:
+              path: './test-file.yaml'
+              selector: '.foo.bar'
+        `,
+      },
+      async (inDir) => {
+        const source = new LiteralSource({
+          $extends: inDir('test-file.yaml'),
+        });
+
+        await expect(source.read([extendsDirective()])).rejects.toThrow();
+      },
+    );
+  });
 });
 
 describe('$env directive', () => {

--- a/app-config/src/extensions.test.ts
+++ b/app-config/src/extensions.test.ts
@@ -2,8 +2,8 @@ import { FileSource, LiteralSource } from './config-source';
 import {
   v1Compat,
   envDirective,
-  selfDirective,
   extendsDirective,
+  extendsSelfDirective,
   overrideDirective,
   encryptedDirective,
   environmentVariableSubstitution,
@@ -338,18 +338,18 @@ describe('$override directive', () => {
   });
 });
 
-describe('$self directive', () => {
-  it('fails when $self selector is invalid', async () => {
+describe('$extendsSelf directive', () => {
+  it('fails when $extendsSelf selector is invalid', async () => {
     const source = new LiteralSource({
       foo: {
-        $self: 'foo.bar',
+        $extendsSelf: 'foo.bar',
       },
     });
 
-    await expect(source.read([selfDirective()])).rejects.toThrow();
+    await expect(source.read([extendsSelfDirective()])).rejects.toThrow();
   });
 
-  it('resolves a simple $self selector', async () => {
+  it('resolves a simple $extendsSelf selector', async () => {
     const source = new LiteralSource({
       foo: {
         bar: {
@@ -357,18 +357,18 @@ describe('$self directive', () => {
         },
       },
       qux: {
-        $self: 'foo.bar',
+        $extendsSelf: 'foo.bar',
       },
     });
 
-    const parsed = await source.read([selfDirective()]);
+    const parsed = await source.read([extendsSelfDirective()]);
     expect(parsed.toJSON()).toEqual({
       foo: { bar: { baz: 42 } },
       qux: { baz: 42 },
     });
   });
 
-  it('resolves a $self selector to a literal value', async () => {
+  it('resolves a $extendsSelf selector to a literal value', async () => {
     const source = new LiteralSource({
       foo: {
         bar: {
@@ -376,11 +376,11 @@ describe('$self directive', () => {
         },
       },
       qux: {
-        $self: 'foo.bar.baz',
+        $extendsSelf: 'foo.bar.baz',
       },
     });
 
-    const parsed = await source.read([selfDirective()]);
+    const parsed = await source.read([extendsSelfDirective()]);
     expect(parsed.toJSON()).toEqual({
       foo: { bar: { baz: 42 } },
       qux: 42,

--- a/app-config/src/extensions.ts
+++ b/app-config/src/extensions.ts
@@ -1,4 +1,4 @@
-import { join, dirname, extname, isAbsolute } from 'path';
+import { join, dirname, extname, resolve, isAbsolute } from 'path';
 import { pathExists } from 'fs-extra';
 import { isObject, Json } from './common';
 import { currentEnvironment, defaultAliases, EnvironmentAliases } from './environment';
@@ -325,6 +325,12 @@ function fileReferenceDirective(keyName: string, meta: ParsedValueMetadata): Par
         // resolve filepaths that are relative to the current FileSource
         if (!isAbsolute(filepath) && context instanceof FileSource) {
           resolvedPath = join(dirname(context.filePath), filepath);
+
+          if (resolve(context.filePath) === resolvedPath) {
+            throw new AppConfigError(
+              `A ${keyName} directive resolved to it's own file (${resolvedPath}). Please use $extendsSelf instead.`,
+            );
+          }
         }
 
         logger.verbose(`Loading file for ${keyName}: ${resolvedPath}`);

--- a/app-config/src/extensions.ts
+++ b/app-config/src/extensions.ts
@@ -18,8 +18,8 @@ export function defaultExtensions(
     v1Compat(),
     envDirective(aliases, environmentOverride),
     extendsDirective(),
+    extendsSelfDirective(),
     overrideDirective(),
-    selfDirective(),
     encryptedDirective(symmetricKey),
     unescape$Directives(),
     environmentVariableSubstitution(aliases, environmentOverride),
@@ -47,22 +47,22 @@ export function overrideDirective(): ParsingExtension {
 }
 
 /** Lookup a property in the same file, and "copy" it */
-export function selfDirective(): ParsingExtension {
+export function extendsSelfDirective(): ParsingExtension {
   return (value, [_, key]) => {
-    if (key !== '$self') return false;
+    if (key !== '$extendsSelf') return false;
 
     return async (parse, _, __, ___, root) => {
       const selector = (await parse(value)).toJSON();
 
       if (typeof selector !== 'string') {
-        throw new AppConfigError(`$self was provided a non-string value`);
+        throw new AppConfigError(`$extendsSelf was provided a non-string value`);
       }
 
       // we temporarily use a ParsedValue literal so that we get the same property lookup semantics
       const selected = ParsedValue.literal(root).property(selector.split('.'));
 
       if (selected === undefined) {
-        throw new AppConfigError(`$self selector was not found (${selector})`);
+        throw new AppConfigError(`$extendsSelf selector was not found (${selector})`);
       }
 
       if (selected.asObject() !== undefined) {


### PR DESCRIPTION
This enables:
1. avoiding "shared" config files (where two spots in the same file `$extends` it)
2. avoiding YAML anchors

Note that a circular reference does crash this at the moment. Wondering what thoughts are around this. Naming is open to change, I started this as `$ref` but was worried about confusion with schema references which hold some slightly different semantics. Another suggestion might be `$extendsSelf` to be consistent with `$extends`.