### PR TITLE
Treats APP_CONFIG variable as "secret"-enough to not trigger schema errors

### DIFF
--- a/app-config/src/config.test.ts
+++ b/app-config/src/config.test.ts
@@ -110,6 +110,25 @@ describe('Configuration Loading', () => {
     );
   });
 
+  it('treats APP_CONFIG variable as secret', async () => {
+    await withTempFiles(
+      {
+        '.app-config.schema.yml': `
+          required: [a, b]
+          additionalProperties: false
+          properties:
+            a: { type: boolean, secret: true }
+            b: { type: boolean }
+        `,
+      },
+      async (inDir) => {
+        process.env.APP_CONFIG = JSON.stringify({ a: true, b: true });
+        const { fullConfig } = await loadValidatedConfig({ directory: inDir('.') });
+        expect(fullConfig).toEqual({ a: true, b: true });
+      },
+    );
+  });
+
   it('loads default values and merges them', async () => {
     await withTempFiles(
       {

--- a/app-config/src/config.ts
+++ b/app-config/src/config.ts
@@ -3,7 +3,7 @@ import { Json, isObject } from './common';
 import { ParsedValue, ParsingExtension } from './parsed-value';
 import { defaultAliases, EnvironmentAliases } from './environment';
 import { FlexibleFileSource, FileSource, EnvironmentSource, FallbackSource } from './config-source';
-import { defaultExtensions, defaultEnvExtensions } from './extensions';
+import { defaultExtensions, defaultEnvExtensions, markAllValuesAsSecret } from './extensions';
 import { loadSchema, Options as SchemaOptions } from './schema';
 import { NotFoundError, WasNotObject, ReservedKeyError } from './errors';
 import { logger } from './logging';
@@ -43,7 +43,7 @@ export async function loadConfig({
   environmentOverride,
   environmentAliases = defaultAliases,
   parsingExtensions = defaultExtensions(environmentAliases, environmentOverride),
-  secretsFileExtensions = parsingExtensions.concat(markAllValuesAsSecret),
+  secretsFileExtensions = parsingExtensions.concat(markAllValuesAsSecret()),
   environmentExtensions = defaultEnvExtensions(),
   defaultValues,
 }: Options = {}): Promise<Configuration> {
@@ -175,9 +175,6 @@ export async function loadValidatedConfig(
 
   return { fullConfig, parsed, ...rest };
 }
-
-const markAllValuesAsSecret: ParsingExtension = (value) => (parse) =>
-  parse(value, { fromSecrets: true });
 
 function verifyParsedValue(parsed: ParsedValue) {
   parsed.visitAll((value) => {

--- a/app-config/src/extensions.ts
+++ b/app-config/src/extensions.ts
@@ -27,7 +27,12 @@ export function defaultExtensions(
 
 /** ParsingExtensions that are used by default in loadConfig for APP_CONFIG variable */
 export function defaultEnvExtensions(): ParsingExtension[] {
-  return [unescape$Directives()];
+  return [unescape$Directives(), markAllValuesAsSecret()];
+}
+
+/** Marks all values recursively as fromSecrets, so they do not trigger schema errors */
+export function markAllValuesAsSecret(): ParsingExtension {
+  return (value) => (parse) => parse(value, { fromSecrets: true });
 }
 
 /** Uses another file as a "base", and extends on top of it */


### PR DESCRIPTION
I'm embarrassed that there wasn't a test against this already. Must have been mid-process and never got finalized.