### PR TITLE
Allows `$env` directives to have siblings, merging with them (with precedent)

### DIFF
--- a/app-config/src/extensions.test.ts
+++ b/app-config/src/extensions.test.ts
@@ -399,6 +399,25 @@ describe('$env directive', () => {
     const parsed = await source.read([envDirective()]);
     expect(parsed.toJSON()).toEqual(null);
   });
+
+  it('merges selection with sibling keys', async () => {
+    const source = new LiteralSource({
+      sibling: true,
+      testing: false,
+      $env: {
+        test: { testing: true },
+        default: { testing: false },
+      },
+    });
+
+    process.env.NODE_ENV = 'test';
+    const parsed = await source.read([envDirective()]);
+    expect(parsed.toJSON()).toEqual({ sibling: true, testing: true });
+
+    process.env.NODE_ENV = 'development';
+    const parsed2 = await source.read([envDirective()]);
+    expect(parsed2.toJSON()).toEqual({ sibling: true, testing: false });
+  });
 });
 
 /* eslint-disable no-template-curly-in-string */

--- a/app-config/src/parsed-value.test.ts
+++ b/app-config/src/parsed-value.test.ts
@@ -284,9 +284,9 @@ describe('ParsedValue', () => {
       d: true,
     });
 
-    expect(value.cloneWhere((v) => !!v.asObject())!.toJSON()).toEqual({ a: {} });
-    expect(value.cloneWhere((v) => v.asArray() !== undefined)!.toJSON()).toEqual({ b: [] });
-    expect(value.cloneWhere((v) => v.asPrimitive() !== undefined)!.toJSON()).toEqual({
+    expect(value.cloneWhere((v) => v.isObject())!.toJSON()).toEqual({ a: {} });
+    expect(value.cloneWhere((v) => v.isArray())!.toJSON()).toEqual({ b: [] });
+    expect(value.cloneWhere((v) => v.isPrimitive())!.toJSON()).toEqual({
       c: '',
       d: true,
     });


### PR DESCRIPTION
The `$env` directive is intended to behave "as expected" when it has siblings. Example:

```yaml
database:
  name: my_app
  $env:
    dev:
      hostname: localhost
      port: 5432
```

This structure should resolve to the expected { name, hostname, port }. Prior to this fix, $env was using shouldFlatten, which will ignore siblings and simply flatten to the given value. This changes that behavior, using `shouldOverride` instead. Upstream, ParsedValue is taught how to deal with non-object merging (treating them as flattening) - this simplifies extensions, as they no longer need to make this check.