### PR TITLE
Adds a validation function in CLI, checking values for every known environment

### DIFF
--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -457,9 +457,21 @@ export const cli = yargs
       {
         name: ['validate'],
         description: 'Checks all environment variants against your schema',
+        options: {
+          environment: {
+            alias: 'env',
+            type: 'string',
+            description: 'Validates only using one environment',
+            group: OptionGroups.Options,
+          },
+        },
       },
-      async () => {
-        await validateAllConfigVariants();
+      async ({ environment }) => {
+        if (environment) {
+          await loadValidatedConfig({ environmentOverride: environment });
+        } else {
+          await validateAllConfigVariants();
+        }
       },
     ),
   )

--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -42,6 +42,7 @@ import {
 import { shouldUseSecretAgent, startAgent, disconnectAgents } from './secret-agent';
 import { loadSchema } from './schema';
 import { generateTypeFiles } from './generate';
+import { validateAllConfigVariants } from './validation';
 import { checkTTY, logger, LogLevel } from './logging';
 import { AppConfigError, FailedToSelectSubObject, EmptyStdinOrPromptResponse } from './errors';
 
@@ -448,6 +449,17 @@ export const cli = yargs
 
         process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format)));
         process.stdout.write('\n');
+      },
+    ),
+  )
+  .command(
+    subcommand(
+      {
+        name: ['validate'],
+        description: 'Checks all environment variants against your schema',
+      },
+      async () => {
+        await validateAllConfigVariants();
       },
     ),
   )

--- a/app-config/src/validation.ts
+++ b/app-config/src/validation.ts
@@ -1,0 +1,72 @@
+import { readdir } from 'fs-extra';
+import { FileSource } from './config-source';
+import { defaultAliases, EnvironmentAliases } from './environment';
+import { loadValidatedConfig } from './config';
+import { logger } from './logging';
+
+export interface Options {
+  directory?: string;
+  environmentAliases?: EnvironmentAliases;
+}
+
+export async function validateAllConfigVariants({
+  directory = '.',
+  environmentAliases = defaultAliases,
+}: Options = {}) {
+  // first, we have to find any applicable app-config files
+  // this is less trivial than config loading, because we can't "assume" the current environment (it could be anything)
+  const filesInDirectory = await readdir(directory);
+  const appConfigFiles = filesInDirectory.filter((filename) =>
+    /^\.app-config\.(?:secrets\.)?(?:.*\.)?(?:yml|yaml|json|json5|toml)$/.exec(filename),
+  );
+
+  const appConfigEnvironments = new Set<string>();
+
+  for (const filename of appConfigFiles) {
+    const environment = /^\.app-config\.(?:secrets\.)?(.*)\.(?:yml|yaml|json|json5|toml)$/.exec(
+      filename,
+    )?.[1];
+
+    if (environment && environment !== 'meta' && environment !== 'schema') {
+      appConfigEnvironments.add(environmentAliases[environment] ?? environment);
+    }
+  }
+
+  await Promise.all(
+    appConfigFiles.map(async (filename) => {
+      const parsed = await new FileSource(filename).read();
+
+      parsed.visitAll((value) => {
+        const obj = value.asObject();
+
+        if (obj?.$env) {
+          for (const key of Object.keys(obj.$env.asObject() ?? {})) {
+            appConfigEnvironments.add(environmentAliases[key] ?? key);
+          }
+        }
+      });
+    }),
+  );
+
+  // remove special-cased names
+  appConfigEnvironments.delete('default');
+  appConfigEnvironments.delete('secrets');
+  appConfigEnvironments.delete('schema');
+  appConfigEnvironments.delete('meta');
+
+  logger.info(
+    `Found ${appConfigEnvironments.size} environments to validate: [${Array.from(
+      appConfigEnvironments,
+    ).join(', ')}]`,
+  );
+
+  for (const environment of appConfigEnvironments) {
+    logger.info(`Validating configuration for environment: ${environment}`);
+
+    await loadValidatedConfig({
+      directory,
+      environmentOverride: environment,
+      environmentVariableName: '', // do not load APP_CONFIG
+    });
+  }
+}


### PR DESCRIPTION
Available as `app-config validate`, this command looks at all detectable app-config files (through a glob, essentially). By inspecting all `$env` keys, we can get a fairly complete list of valid / possible environments.

Once we have a list of environments, just load the config from scratch with that as environmentOverride. Note that we loadConfig without much customization (eg. fileNameBase, parsingExtensions). That's probably possible in the future, but probably isn't necessary for the time being.

This is probably most useful as a CI check for projects. Helps avoid the issue of "oops - forgot a production value" at deploy time.

Looking for thoughts on anything additional or related that belongs with this kind of feature. Or, if the feature even has merit (implementation is a bit ugly).