### PR TITLE
Adds a "raw" format option for `app-config create` format

### DIFF
--- a/app-config/src/__snapshots__/cli.test.ts.snap
+++ b/app-config/src/__snapshots__/cli.test.ts.snap
@@ -38,6 +38,12 @@ exports[`create prints YAML format 1`] = `
 "
 `;
 
+exports[`create prints raw format 1`] = `"true"`;
+
+exports[`create prints raw format 2`] = `"83.2"`;
+
+exports[`create prints raw format 3`] = `"foo"`;
+
 exports[`create prints simple app-config file 1`] = `
 "foo: true
 "

--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -117,6 +117,37 @@ describe('create', () => {
     expect(stdout).toMatchSnapshot();
   });
 
+  it('prints raw format', async () => {
+    const APP_CONFIG = JSON.stringify({
+      anObject: {},
+      aBoolean: true,
+      aNumber: 83.2,
+      aString: 'foo',
+    });
+
+    const { stdout: out1 } = await run(
+      ['create', '-q', '--format', 'raw', '--select', '#/aBoolean'],
+      { env: { APP_CONFIG } },
+    );
+    expect(out1).toMatchSnapshot();
+
+    const { stdout: out2 } = await run(
+      ['create', '-q', '--format', 'raw', '--select', '#/aNumber'],
+      { env: { APP_CONFIG } },
+    );
+    expect(out2).toMatchSnapshot();
+
+    const { stdout: out3 } = await run(
+      ['create', '-q', '--format', 'raw', '--select', '#/aString'],
+      { env: { APP_CONFIG } },
+    );
+    expect(out3).toMatchSnapshot();
+
+    await expect(
+      run(['create', '-q', '--format', 'raw', '--select', '#/anObject'], { env: { APP_CONFIG } }),
+    ).rejects.toThrow();
+  });
+
   it('can select a nested property', async () => {
     const APP_CONFIG = JSON.stringify({ a: { b: { c: true } } });
     const { stdout: nested1 } = await run(['create', '-q', '--format', 'json', '--select', '#/a'], {

--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -180,7 +180,7 @@ const formatOption = {
   alias: 'f',
   type: 'string',
   default: 'yaml' as string,
-  choices: ['yaml', 'yml', 'json', 'json5', 'toml'],
+  choices: ['yaml', 'yml', 'json', 'json5', 'toml', 'raw'],
   group: OptionGroups.Options,
 } as const;
 
@@ -299,6 +299,8 @@ function fileTypeForFormatOption(option: string): FileType {
     case 'yml':
     case 'yaml':
       return FileType.YAML;
+    case 'raw':
+      return FileType.RAW;
     default:
       throw new AppConfigError(`${option} is not a valid file type`);
   }

--- a/app-config/src/config-source.ts
+++ b/app-config/src/config-source.ts
@@ -14,6 +14,9 @@ export enum FileType {
   TOML = 'TOML',
   JSON = 'JSON',
   JSON5 = 'JSON5',
+
+  /** @hidden Raw is only used for CLI output */
+  RAW = 'RAW',
 }
 
 /** Base class for "sources", which are strategies to read configuration (eg. files, environment variables) */
@@ -273,6 +276,12 @@ export function stringify(config: Json, fileType: FileType, minimal: boolean = f
       return stringifyTOML(config as any);
     case FileType.YAML:
       return stringifyYAML(config);
+    case FileType.RAW: {
+      if (typeof config === 'string') return config;
+      if (typeof config === 'number') return `${config}`;
+      if (typeof config === 'boolean') return config ? 'true' : 'false';
+      throw new BadFileType(`Stringifying "raw" only works with primitive values`);
+    }
 
     default:
       throw new BadFileType(`Unsupported FileType '${fileType as string}'`);


### PR DESCRIPTION
This acts as a nice alternative to `app-config create --format json | jq -r`. In particular, I've been finding a few use cases where it's nice to compose app-config for CLI arguments.

```
gq $(app-config c -f json --select \"#/graphQL\") \
  -H \"x-hasura-admin-secret: $(app-config c -s -C ../hasura -f yml --select \"#/adminSecret\")\" --introspect \
   > schema.graphql
```

This ends up mostly-sorta working, but relies on unquoted YAML strings (sometimes quotes are required).

Naturally, "raw" only works for primitive, unambiguous values - strings, numbers and booleans.