### PR TITLE
Draft 1 of Specification (Non-JS Language Interop)

### DIFF
--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -425,4 +425,30 @@ describe('nested commands', () => {
 
     expect(stdout.includes('APP_CONFIG={"foo":true}')).toBe(true);
   });
+
+  it('passes APP_CONFIG_SCHEMA variable in', async () => {
+    await withTempFiles(
+      {
+        '.app-config.yml': `
+          foo: true
+        `,
+        '.app-config.schema.yml': `
+          $schema: http://json-schema.org/draft-07/schema
+          type: object
+          properties:
+            foo: { type: boolean }
+        `,
+      },
+      async (inDir) => {
+        const { stdout } = await run(['--format', 'json', '-C', inDir('.'), '--', 'env']);
+
+        expect(stdout.includes('APP_CONFIG={"foo":true}')).toBe(true);
+        expect(
+          stdout.includes(
+            'APP_CONFIG_SCHEMA={"$schema":"http://json-schema.org/draft-07/schema","type":"object","properties":{"foo":{"type":"boolean"}}}',
+          ),
+        ).toBe(true);
+      },
+    );
+  });
 });

--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -398,7 +398,7 @@ describe('create-schema', () => {
 
 describe('nested commands', () => {
   it('fails with no app-config', async () => {
-    await expect(run(['-q', '--', 'env'])).rejects.toThrow();
+    await expect(run(['-q', '--', isWindows ? 'SET' : 'env'])).rejects.toThrow();
   });
 
   it('passes environment variables down', async () => {
@@ -440,7 +440,14 @@ describe('nested commands', () => {
         `,
       },
       async (inDir) => {
-        const { stdout } = await run(['--format', 'json', '-C', inDir('.'), '--', 'env']);
+        const { stdout } = await run([
+          '--format',
+          'json',
+          '-C',
+          inDir('.'),
+          '--',
+          isWindows ? 'SET' : 'env',
+        ]);
 
         expect(stdout.includes('APP_CONFIG={"foo":true}')).toBe(true);
         expect(

--- a/app-config/src/errors.ts
+++ b/app-config/src/errors.ts
@@ -19,9 +19,6 @@ export class WasNotObject extends AppConfigError {}
 /** Error during schema validation */
 export class ValidationError extends AppConfigError {}
 
-/** Secret values were found in a non-secret file */
-export class SecretsInNonSecrets extends ValidationError {}
-
 /** For encrypting and decrypting secrets, stdin is required for prompts sometimes */
 export class SecretsRequireTTYError extends AppConfigError {}
 

--- a/app-config/src/generate.test.ts
+++ b/app-config/src/generate.test.ts
@@ -10,7 +10,7 @@ describe('TypeScript File Generation', () => {
       properties: {
         foo: { type: 'string' },
       },
-    };
+    } as const;
 
     const generated = await generateQuicktype(schema, 'ts', 'Configuration');
 
@@ -135,7 +135,7 @@ describe('Flow File Generation', () => {
       properties: {
         foo: { type: 'string' },
       },
-    };
+    } as const;
 
     const generated = await generateQuicktype(schema, 'flow', 'Configuration');
 
@@ -151,7 +151,7 @@ describe('Golang File Generation', () => {
       properties: {
         foo: { type: 'string' },
       },
-    };
+    } as const;
 
     const generated = await generateQuicktype(schema, 'go', 'Configuration');
 
@@ -167,7 +167,7 @@ describe('Rust File Generation', () => {
       properties: {
         foo: { type: 'string' },
       },
-    };
+    } as const;
 
     const generated = await generateQuicktype(schema, 'rust', 'Configuration');
 

--- a/app-config/src/generate.ts
+++ b/app-config/src/generate.ts
@@ -7,9 +7,8 @@ import {
   JSONSchemaSourceData,
   InputData,
 } from 'quicktype-core';
-import { JsonObject } from './common';
 import { loadMetaConfig, Options as MetaOptions } from './meta';
-import { loadSchema, Options as SchemaOptions } from './schema';
+import { loadSchema, JSONSchema, Options as SchemaOptions } from './schema';
 import { logger } from './logging';
 
 export interface Options {
@@ -66,7 +65,7 @@ export async function generateTypeFiles({ directory, schemaOptions, metaOptions 
 }
 
 export async function generateQuicktype(
-  schema: JsonObject,
+  schema: JSONSchema,
   type: string,
   name: string,
   augmentModule: boolean = true,

--- a/app-config/src/schema.test.ts
+++ b/app-config/src/schema.test.ts
@@ -10,6 +10,20 @@ describe('Schema Loading', () => {
     await expect(loadSchema()).rejects.toThrow();
   });
 
+  it('loads schema from APP_CONFIG_SCHEMA variable', async () => {
+    process.env.APP_CONFIG_SCHEMA = JSON.stringify({
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    });
+
+    const { value } = await loadSchema();
+
+    expect(value).toMatchObject({
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    });
+  });
+
   it('loads a simple YAML schema', async () => {
     await withTempFiles(
       {

--- a/app-config/src/schema.ts
+++ b/app-config/src/schema.ts
@@ -1,21 +1,26 @@
 import { join, relative, resolve } from 'path';
 import Ajv from 'ajv';
 import addFormats from 'ajv-formats';
-import RefParser, { bundle } from 'json-schema-ref-parser';
+import RefParser, { JSONSchema, bundle } from 'json-schema-ref-parser';
 import { JsonObject, isObject, isWindows } from './common';
 import { ParsedValue, ParsingExtension } from './parsed-value';
 import { defaultAliases, EnvironmentAliases } from './environment';
 import {
+  EnvironmentSource,
   FlexibleFileSource,
   FileSource,
   parseRawString,
   filePathAssumedType,
 } from './config-source';
-import { ValidationError, WasNotObject } from './errors';
+import { ValidationError, SecretsInNonSecrets, WasNotObject, NotFoundError } from './errors';
+import { logger } from './logging';
+
+export { JSONSchema };
 
 export interface Options {
   directory?: string;
   fileNameBase?: string;
+  environmentVariableName?: string;
   environmentOverride?: string;
   environmentAliases?: EnvironmentAliases;
   parsingExtensions?: ParsingExtension[];
@@ -24,27 +29,55 @@ export interface Options {
 export type Validate = (fullConfig: JsonObject, parsed?: ParsedValue) => void;
 
 export interface Schema {
-  value: JsonObject;
+  value: JSONSchema;
   validate: Validate;
 }
 
 export async function loadSchema({
   directory = '.',
   fileNameBase = '.app-config.schema',
+  environmentVariableName = 'APP_CONFIG_SCHEMA',
   environmentOverride,
   environmentAliases = defaultAliases,
   parsingExtensions = [],
 }: Options = {}): Promise<Schema> {
-  const source = new FlexibleFileSource(
-    join(directory, fileNameBase),
-    environmentOverride,
-    environmentAliases,
-  );
+  const env = new EnvironmentSource(environmentVariableName);
+  logger.verbose(`Trying to read ${environmentVariableName} for schema`);
 
-  const parsed = await source.read(parsingExtensions);
+  let parsed: ParsedValue | undefined;
+
+  parsed = await env.read(parsingExtensions).catch((error) => {
+    // having no APP_CONFIG_SCHEMA environment variable is normal, and should fall through to reading files
+    if (error instanceof NotFoundError) {
+      return undefined;
+    }
+
+    return Promise.reject(error);
+  });
+
+  if (!parsed) {
+    logger.verbose(`Searching for ${fileNameBase} file`);
+
+    const source = new FlexibleFileSource(
+      join(directory, fileNameBase),
+      environmentOverride,
+      environmentAliases,
+    );
+
+    parsed = await source.read(parsingExtensions);
+  }
+
   const parsedObject = parsed.toJSON();
 
   if (!isObject(parsedObject)) throw new WasNotObject('JSON Schema was not an object');
+
+  logger.verbose(
+    `Loaded schema from ${
+      parsed.getSource(FileSource)?.filePath ??
+      parsed.getSource(EnvironmentSource)?.variableName ??
+      'unknown source'
+    }`,
+  );
 
   // default to draft 07
   if (!parsedObject.$schema) {
@@ -116,10 +149,7 @@ export async function loadSchema({
   };
 }
 
-async function normalizeSchema(
-  schema: JsonObject,
-  directory: string,
-): Promise<RefParser.JSONSchema> {
+async function normalizeSchema(schema: JsonObject, directory: string): Promise<JSONSchema> {
   // NOTE: http is enabled by default
   const resolveOptions: RefParser.Options['resolve'] = {
     file: {

--- a/app-config/src/schema.ts
+++ b/app-config/src/schema.ts
@@ -12,7 +12,7 @@ import {
   parseRawString,
   filePathAssumedType,
 } from './config-source';
-import { ValidationError, SecretsInNonSecrets, WasNotObject, NotFoundError } from './errors';
+import { ValidationError, WasNotObject, NotFoundError } from './errors';
 import { logger } from './logging';
 
 export { JSONSchema };

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -48,12 +48,6 @@ The exact version to use when a schema is ambiguous is up to library authors.
 Non-standard JSON Schema keywords should be ignored. In particular, the "secret" key is often used.
 Because library authors are only required to load environment variables, we don't require checking "secretness".
 
-**To be liberal, a library can skip JSON Schema validation**.
-We encourage authors not to do this, but we intend for this specification to be very minimal.
-So if your language has no off the shelf libraries for JSON Schema, it may be unreasonable.
-In these cases, we strongly encourage strict object-structure validation, at the least.
-We don't want users to receive unexpected values from App Config, which is exactly what the library is meant to avoid.
-
 ## Library Interface
 
 Libraries that are App Config Compliant should provide one function:

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -21,7 +21,7 @@ We'll separate parts of App Config:
 So to be clear, **this spec will not define #1 or #4**. These are non-trivial
 parts of App Config, and would be a lot to replicate truthfully in every language.
 
-Instead, we'll try to outline #1 and #3. These may not describe _every_ feature
+Instead, we'll try to outline #2 and #3. These may not describe _every_ feature
 that the App Config library supports, but App Config should faithfully fulfil the requirements.
 
 ## Loading App Config through an environment variable

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,3 +1,110 @@
 ---
 title: Specification
 ---
+
+This document defines the exact instructions required to be "App Config Compliant".
+What does that mean? App Config intends to be more than a library confined to the Node.js ecosystem.
+So in that spirit, we're providing instructions for language bindings to follow in order to interoperate.
+
+Does that mean we want N+1 ports of the App Config package? No, not really.
+This spec defines **minimal required support**, and App Config itself will be free to provide more features.
+
+## High Level Overview
+
+We'll separate parts of App Config:
+
+1. Loading App Config through files
+2. Loading App Config through an environment variable
+3. JSON Schema Validation
+4. Parsing extensions and environment-specific features
+
+So to be clear, **this spec will not define #1 or #4**. These are non-trivial
+parts of App Config, and would be a lot to replicate truthfully in every language.
+
+Instead, we'll try to outline #1 and #3. These may not describe _every_ feature
+that the App Config library supports, but App Config should faithfully fulfil the requirements.
+
+## Loading App Config through an environment variable
+
+App Config is defined as an environment variable. This variable is named `APP_CONFIG`.
+Libraries can support different names, but all should use `APP_CONFIG` by default.
+
+This environment variable should be a string, containing text that can be parsed as JSON.
+This JSON value should an object. Libraries should reject invalid JSON strings or non-objects, if possible.
+
+## JSON Schema Validation
+
+Whether the value contained in `APP_CONFIG` is valid is up to the schema.
+
+Schemas are JSON files, with the exact name `.app-config.schema.json`.
+This file should be present in the working directory, but libraries should provide an option for this.
+
+A missing schema file should result in an error, unless the library provides a non-validation opt-out option.
+
+Schemas should follow the exact specification of [JSON Schema](https://json-schema.org/specification.html).
+Users tend to use draft releases of this spec, so libraries are encouraged to support as many versions as possible.
+The exact version to use when a schema is ambiguous is up to library authors.
+
+Non-standard JSON Schema keywords should be ignored. In particular, the "secret" key is often used.
+Because library authors are only required to load environment variables, we don't require checking "secretness".
+
+**To be liberal, a library can skip JSON Schema validation**.
+We encourage authors not to do this, but we intend for this specification to be very minimal.
+So if your language has no off the shelf libraries for JSON Schema, it may be unreasonable.
+In these cases, we strongly encourage strict object-structure validation, at the least.
+We don't want users to receive unexpected values from App Config, which is exactly what the library is meant to avoid.
+
+## Library Interface
+
+Libraries that are App Config Compliant should provide one function:
+
+```
+# In pseudo-code form:
+
+fn load_configuration(options?) -> ConfigurationObject
+```
+
+This function can be "async", or provide different ways of calling it.
+It's also common to define a global variable or singleton instance.
+Options can be library-defined. You might provide options for CWD, environment variable name, no-validation, etc.
+
+## Official Libraries
+
+The App Config library intends to officially support as many of these libraries as we can.
+Primarily, we believe that we can leverage our existing tooling to "jump start" these efforts.
+
+In many languages, it should be possible to dynamically **generate an App Config Compliant library for you**.
+This is especially easy in strongly typed languages, like golang, Rust or Java.
+
+We're currently experimenting with:
+
+- golang (using xeipuuv/gojsonschema)
+- rust (using valico)
+
+## Interoperation
+
+We've defined a really small subset in this document. The last thing we want
+is to encourage not using the features of App Config. Instead, we want App Config
+to provide the tools you need for development. In production, you can "bootstrap"
+configuration to be compatible with your language without the App Config library.
+
+The intention here, is for development to look like:
+
+```sh
+npx @lcdev/app-config -s -- go run .
+```
+
+And for production to look like:
+
+```sh
+# extract configuration for the deployment environment, and expose it as an environment variable
+APP_CONFIG=$(NODE_ENV=qa npx @lcdev/app-config -s create --format json)
+
+# normalize your development schema into a JSON file, ensuring that it's present in production
+npx @lcdev/app-config create-schema --format json > .app-config.schema.json
+```
+
+This is a simple example, meant to show not tell. The idea is that `@lcdev/app-config`
+itself is used for creating the final values / files that your app uses. This allows
+your app to use the configuration easily without having to know about complicated
+parsing extensions, inter-file dependencies, etc.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -36,10 +36,9 @@ This JSON value should an object. Libraries should reject invalid JSON strings o
 
 Whether the value contained in `APP_CONFIG` is valid is up to the schema.
 
-Schemas are JSON files, with the exact name `.app-config.schema.json`.
-This file should be present in the working directory, but libraries should provide an option for this.
+Schemas are JSON values, exposed through another environment variable named `APP_CONFIG_SCHEMA`.
 
-A missing schema file should result in an error, unless the library provides a non-validation opt-out option.
+A missing schema should result in an error, unless the library provides a non-validation opt-out option.
 
 Schemas should follow the exact specification of [JSON Schema](https://json-schema.org/specification.html).
 Users tend to use draft releases of this spec, so libraries are encouraged to support as many versions as possible.
@@ -95,11 +94,11 @@ And for production to look like:
 # extract configuration for the deployment environment, and expose it as an environment variable
 APP_CONFIG=$(NODE_ENV=qa npx @lcdev/app-config -s create --format json)
 
-# normalize your development schema into a JSON file, ensuring that it's present in production
-npx @lcdev/app-config create-schema --format json > .app-config.schema.json
+# normalize your development schema, ensuring that it's present in production
+APP_CONFIG_SCHEMA=$(npx @lcdev/app-config create-schema --format json)
 ```
 
 This is a simple example, meant to show not tell. The idea is that `@lcdev/app-config`
-itself is used for creating the final values / files that your app uses. This allows
-your app to use the configuration easily without having to know about complicated
-parsing extensions, inter-file dependencies, etc.
+itself is used for creating the final values that your app uses. This allows your app
+to use the configuration easily without having to know about complicated parsing
+extensions, inter-file dependencies, etc.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -79,8 +79,9 @@ We're currently experimenting with:
 
 We've defined a really small subset in this document. The last thing we want
 is to encourage not using the features of App Config. Instead, we want App Config
-to provide the tools you need for development. In production, you can "bootstrap"
-configuration to be compatible with your language without the App Config library.
+to provide the tools you need for development. Features like `$extends` and `$env`
+are useful for developers, and be "erased" by the time your app goes to production.
+By not needing these features, language support can be simple.
 
 The intention here, is for development to look like:
 


### PR DESCRIPTION
Closes #46.

Starts to define what "compliant" means, and ideally, define exactly how to use the app-config package to feed compliant libraries. Looking for feedback!