### PR TITLE
Normalizes JSON schema references centrally, simplifying logic

### DIFF
--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -1,5 +1,6 @@
 import execa from 'execa';
 import { join } from 'path';
+import { isWindows } from './common';
 import { withTempFiles } from './test-util';
 
 const run = async (argv: string[], options?: execa.Options) =>
@@ -371,21 +372,25 @@ describe('nested commands', () => {
 
   it('passes environment variables down', async () => {
     const APP_CONFIG = JSON.stringify({ foo: true });
-    const { stdout } = await run(['-q', '--', 'env'], { env: { APP_CONFIG } });
+    const { stdout } = await run(['-q', '--', isWindows ? 'SET' : 'env'], { env: { APP_CONFIG } });
 
     expect(stdout.includes('APP_CONFIG_FOO=true')).toBe(true);
   });
 
   it('uses prefix in environment variables', async () => {
     const APP_CONFIG = JSON.stringify({ foo: true });
-    const { stdout } = await run(['-q', '-p', 'MY_CONFIG', '--', 'env'], { env: { APP_CONFIG } });
+    const { stdout } = await run(['-q', '-p', 'MY_CONFIG', '--', isWindows ? 'SET' : 'env'], {
+      env: { APP_CONFIG },
+    });
 
     expect(stdout.includes('MY_CONFIG_FOO=true')).toBe(true);
   });
 
   it('uses file format in main environment variable', async () => {
     const APP_CONFIG = JSON.stringify({ foo: true });
-    const { stdout } = await run(['-q', '--format', 'json', '--', 'env'], { env: { APP_CONFIG } });
+    const { stdout } = await run(['-q', '--format', 'json', '--', isWindows ? 'SET' : 'env'], {
+      env: { APP_CONFIG },
+    });
 
     expect(stdout.includes('APP_CONFIG={"foo":true}')).toBe(true);
   });

--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -4,7 +4,7 @@ import * as yargs from 'yargs';
 import execa from 'execa';
 import clipboardy from 'clipboardy';
 import { outputFile, readFile } from 'fs-extra';
-import { resolve, dereference } from 'json-schema-ref-parser';
+import { resolve } from 'json-schema-ref-parser';
 import { stripIndents } from 'common-tags';
 import {
   promptUser,
@@ -435,17 +435,16 @@ export const cli = yargs
 
         let toPrint: Json;
 
-        const normalized = await dereference(schema);
-        const refs = await resolve(normalized);
-
         if (opts.select) {
+          const refs = await resolve(schema);
+
           toPrint = refs.get(opts.select);
 
           if (toPrint === undefined) {
             throw new FailedToSelectSubObject(`Failed to select property ${opts.select}`);
           }
         } else {
-          toPrint = refs.get('#');
+          toPrint = schema;
         }
 
         process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format)));

--- a/app-config/src/common.ts
+++ b/app-config/src/common.ts
@@ -128,3 +128,5 @@ export async function consumeStdin(): Promise<string> {
     rl.on('close', () => resolve(buffer));
   });
 }
+
+export const isWindows = /^win/.test(process.platform);

--- a/app-config/src/schema.test.ts
+++ b/app-config/src/schema.test.ts
@@ -130,6 +130,96 @@ describe('Schema Loading', () => {
   });
 
   describe('References', () => {
+    it('resolves schema $ref to a TOML file', async () => {
+      await withTempFiles(
+        {
+          '.app-config.schema.yml': `
+            type: object
+            properties:
+              a:
+                $ref: './referenced.schema.toml#/definitions/A'
+          `,
+          'referenced.schema.toml': `
+            [definitions]
+            A = { "type" = "number" }
+          `,
+        },
+        async (inDir) => {
+          const { value: schema } = await loadSchema({ directory: inDir('.') });
+
+          expect(schema.properties).toEqual({ a: { type: 'number' } });
+        },
+      );
+    });
+
+    it('resolves schema $ref to a JSON file', async () => {
+      await withTempFiles(
+        {
+          '.app-config.schema.yml': `
+            type: object
+            properties:
+              a:
+                $ref: './referenced.schema.json#/definitions/A'
+          `,
+          'referenced.schema.json': `{
+            "definitions": {
+              "A": { "type": "number" }
+            }
+          }`,
+        },
+        async (inDir) => {
+          const { value: schema } = await loadSchema({ directory: inDir('.') });
+
+          expect(schema.properties).toEqual({ a: { type: 'number' } });
+        },
+      );
+    });
+
+    it('resolves schema $ref to a JSON5 file', async () => {
+      await withTempFiles(
+        {
+          '.app-config.schema.yml': `
+            type: object
+            properties:
+              a:
+                $ref: './referenced.schema.json5#/definitions/A'
+          `,
+          'referenced.schema.json5': `{
+            definitions: {
+              A: { type: "number" }
+            }
+          }`,
+        },
+        async (inDir) => {
+          const { value: schema } = await loadSchema({ directory: inDir('.') });
+
+          expect(schema.properties).toEqual({ a: { type: 'number' } });
+        },
+      );
+    });
+
+    it('resolves schema $ref to a YAML file', async () => {
+      await withTempFiles(
+        {
+          '.app-config.schema.yml': `
+            type: object
+            properties:
+              a:
+                $ref: './referenced.schema.yaml#/definitions/A'
+          `,
+          'referenced.schema.yaml': `
+            definitions:
+              A: { type: 'number' }
+          `,
+        },
+        async (inDir) => {
+          const { value: schema } = await loadSchema({ directory: inDir('.') });
+
+          expect(schema.properties).toEqual({ a: { type: 'number' } });
+        },
+      );
+    });
+
     it('loads a schema $ref relative to itself', async () => {
       await withTempFiles(
         {
@@ -244,7 +334,7 @@ describe('Schema Loading', () => {
           expect(a).toMatchObject({
             properties: {
               x: {
-                $ref: inDir('b/.app-config.schema.yml#/definitions/B'),
+                type: 'string',
               },
             },
           });
@@ -252,7 +342,7 @@ describe('Schema Loading', () => {
           expect(b).toMatchObject({
             properties: {
               x: {
-                $ref: inDir('a/.app-config.schema.yml#/definitions/A'),
+                type: 'string',
               },
             },
           });
@@ -280,7 +370,7 @@ describe('Schema Loading', () => {
           expect(value).toMatchObject({
             properties: {
               x: {
-                $ref: inDir('my%20schema.yml#/definitions/B'),
+                type: 'string',
               },
             },
           });

--- a/app-config/src/schema.ts
+++ b/app-config/src/schema.ts
@@ -157,8 +157,6 @@ async function normalizeSchema(
             throw new WasNotObject(`JSON Schema was not an object (${file.url})`);
           }
 
-          parsed.$id = file.url;
-
           return parsed;
         },
       },

--- a/app-config/src/schema.ts
+++ b/app-config/src/schema.ts
@@ -1,7 +1,7 @@
 import { join, relative, resolve } from 'path';
 import Ajv from 'ajv';
 import RefParser, { bundle } from 'json-schema-ref-parser';
-import { JsonObject, isObject } from './common';
+import { JsonObject, isObject, isWindows } from './common';
 import { ParsedValue, ParsingExtension } from './parsed-value';
 import { defaultAliases, EnvironmentAliases } from './environment';
 import {
@@ -169,7 +169,6 @@ async function normalizeSchema(
 }
 
 // ALL BELOW IS FROM https://github.com/APIDevTools/json-schema-ref-parser/blob/d3bc1985a9a1d301a5eddc7a4bbfaca542887d8c/lib/util/url.js
-const isWindows = /^win/.test(process.platform);
 const forwardSlashPattern = /\//g;
 const urlDecodePatterns = [/%23/g, '#', /%24/g, '$', /%26/g, '&', /%2C/g, ',', /%40/g, '@'];
 

--- a/app-config/src/secret-agent.ts
+++ b/app-config/src/secret-agent.ts
@@ -127,7 +127,7 @@ export async function connectAgent(
     if (closeTimeout) clearTimeout(closeTimeout);
     if (closeTimeoutMs === Infinity) return;
 
-    closeTimeout = setTimeout(() => {
+    closeTimeout = global.setTimeout(() => {
       logger.verbose('Closing websocket');
 
       client.close().finally(() => {


### PR DESCRIPTION
- Benefits codegen by avoiding references alltogether
- Supports remote / URL references out of the box
- Simplifies the path to exposing a `APP_CONFIG_SCHEMA` variable for spec-compliant libraries
- Simplifies the logic of `create-schema`, and removes inconsistencies
- Should at least get us closer to fixing #47, if not just plain fixing it

We previously avoiding doing this because of v1's `Sync` interfaces, which would be incompatible. Thankfully, we get to simplify this now.

Naturally, this may affect some behavior. All tests still passed, so any breaking here was untested (and if things pop up, we'll add tests for them).