### PR TITLE
Support for `APP_CONFIG_SCHEMA` environment variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          # FIXME: - windows-latest
+          - windows-latest
         node-version: [10.x, 12.x, 14.x, 15.x]
 
     runs-on: ${{ matrix.os }}

--- a/app-config/src/__snapshots__/cli.test.ts.snap
+++ b/app-config/src/__snapshots__/cli.test.ts.snap
@@ -1,32 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`create can select a nested property 1`] = `
-"{
-  \\"b\\": {
-    \\"c\\": true
-  }
-}"
-`;
+exports[`create can select a nested property 1`] = `"{\\"b\\":{\\"c\\":true}}"`;
 
-exports[`create can select a nested property 2`] = `
-"{
-  \\"c\\": true
-}"
-`;
+exports[`create can select a nested property 2`] = `"{\\"c\\":true}"`;
 
 exports[`create can select a nested property 3`] = `"true"`;
 
-exports[`create prints JSON format 1`] = `
-"{
-  \\"foo\\": true
-}"
-`;
+exports[`create prints JSON format 1`] = `"{\\"foo\\":true}"`;
 
-exports[`create prints JSON5 format 1`] = `
-"{
-  foo: true,
-}"
-`;
+exports[`create prints JSON5 format 1`] = `"{foo:true}"`;
 
 exports[`create prints TOML format 1`] = `
 "foo = true
@@ -79,29 +61,9 @@ properties:
 "
 `;
 
-exports[`create-schema prints JSON format 1`] = `
-"{
-  \\"type\\": \\"object\\",
-  \\"properties\\": {
-    \\"foo\\": {
-      \\"type\\": \\"boolean\\"
-    }
-  },
-  \\"$schema\\": \\"http://json-schema.org/draft-07/schema#\\"
-}"
-`;
+exports[`create-schema prints JSON format 1`] = `"{\\"type\\":\\"object\\",\\"properties\\":{\\"foo\\":{\\"type\\":\\"boolean\\"}},\\"$schema\\":\\"http://json-schema.org/draft-07/schema#\\"}"`;
 
-exports[`create-schema prints JSON5 format 1`] = `
-"{
-  type: 'object',
-  properties: {
-    foo: {
-      type: 'boolean',
-    },
-  },
-  $schema: 'http://json-schema.org/draft-07/schema#',
-}"
-`;
+exports[`create-schema prints JSON5 format 1`] = `"{type:'object',properties:{foo:{type:'boolean'}},$schema:'http://json-schema.org/draft-07/schema#'}"`;
 
 exports[`create-schema prints TOML format 1`] = `
 "type = \\"object\\"

--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -425,4 +425,30 @@ describe('nested commands', () => {
 
     expect(stdout.includes('APP_CONFIG={"foo":true}')).toBe(true);
   });
+
+  it('passes APP_CONFIG_SCHEMA variable in', async () => {
+    await withTempFiles(
+      {
+        '.app-config.yml': `
+          foo: true
+        `,
+        '.app-config.schema.yml': `
+          $schema: http://json-schema.org/draft-07/schema
+          type: object
+          properties:
+            foo: { type: boolean }
+        `,
+      },
+      async (inDir) => {
+        const { stdout } = await run(['--format', 'json', '-C', inDir('.'), '--', 'env']);
+
+        expect(stdout.includes('APP_CONFIG={"foo":true}')).toBe(true);
+        expect(
+          stdout.includes(
+            'APP_CONFIG_SCHEMA={"$schema":"http://json-schema.org/draft-07/schema","type":"object","properties":{"foo":{"type":"boolean"}}}',
+          ),
+        ).toBe(true);
+      },
+    );
+  });
 });

--- a/app-config/src/cli.test.ts
+++ b/app-config/src/cli.test.ts
@@ -398,7 +398,7 @@ describe('create-schema', () => {
 
 describe('nested commands', () => {
   it('fails with no app-config', async () => {
-    await expect(run(['-q', '--', 'env'])).rejects.toThrow();
+    await expect(run(['-q', '--', isWindows ? 'SET' : 'env'])).rejects.toThrow();
   });
 
   it('passes environment variables down', async () => {
@@ -440,7 +440,14 @@ describe('nested commands', () => {
         `,
       },
       async (inDir) => {
-        const { stdout } = await run(['--format', 'json', '-C', inDir('.'), '--', 'env']);
+        const { stdout } = await run([
+          '--format',
+          'json',
+          '-C',
+          inDir('.'),
+          '--',
+          isWindows ? 'SET' : 'env',
+        ]);
 
         expect(stdout.includes('APP_CONFIG={"foo":true}')).toBe(true);
         expect(

--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -40,7 +40,7 @@ import {
   untrustTeamMember,
 } from './encryption';
 import { shouldUseSecretAgent, startAgent, disconnectAgents } from './secret-agent';
-import { loadSchema } from './schema';
+import { loadSchema, JSONSchema } from './schema';
 import { generateTypeFiles } from './generate';
 import { validateAllConfigVariants } from './validation';
 import { checkTTY, logger, LogLevel } from './logging';
@@ -221,7 +221,7 @@ async function loadConfigWithOptions({
   fileNameBase,
   environmentOverride,
   environmentVariableName,
-}: LoadConfigCLIOptions): Promise<JsonObject> {
+}: LoadConfigCLIOptions): Promise<[JsonObject, JSONSchema | undefined]> {
   const options: LoadConfigOptions = {
     fileNameBase,
     environmentOverride,
@@ -235,7 +235,7 @@ async function loadConfigWithOptions({
     loaded = await loadValidatedConfig(options);
   }
 
-  const { fullConfig, parsedNonSecrets } = loaded;
+  const { fullConfig, parsedNonSecrets, schema } = loaded;
 
   let jsonConfig: JsonObject;
 
@@ -253,7 +253,7 @@ async function loadConfigWithOptions({
     }
   }
 
-  return jsonConfig;
+  return [jsonConfig, schema];
 }
 
 async function loadVarsWithOptions({
@@ -267,8 +267,8 @@ async function loadVarsWithOptions({
   rename?: string[];
   alias?: string[];
   only?: string[];
-}): Promise<[ReturnType<typeof flattenObjectTree>, JsonObject]> {
-  const config = await loadConfigWithOptions(opts);
+}): Promise<[ReturnType<typeof flattenObjectTree>, JsonObject, JSONSchema | undefined]> {
+  const [config, schema] = await loadConfigWithOptions(opts);
   let flattened = flattenObjectTree(config, prefix);
 
   flattened = renameInFlattenedTree(flattened, rename, false);
@@ -283,10 +283,10 @@ async function loadVarsWithOptions({
       }
     }
 
-    return [filtered, config];
+    return [filtered, config, schema];
   }
 
-  return [flattened, config];
+  return [flattened, config, schema];
 }
 
 function fileTypeForFormatOption(option: string): FileType {
@@ -407,7 +407,7 @@ export const cli = yargs
       async (opts) => {
         shouldUseSecretAgent(opts.agent);
 
-        const toPrint = await loadConfigWithOptions(opts);
+        const [toPrint] = await loadConfigWithOptions(opts);
 
         process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format)));
         process.stdout.write('\n');
@@ -446,7 +446,7 @@ export const cli = yargs
             throw new FailedToSelectSubObject(`Failed to select property ${opts.select}`);
           }
         } else {
-          toPrint = schema;
+          toPrint = schema as Json;
         }
 
         process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format)));
@@ -877,14 +877,27 @@ export const cli = yargs
           process.exit(1);
         }
 
-        const [env, fullConfig] = await loadVarsWithOptions(opts);
+        const [env, fullConfig, schema] = await loadVarsWithOptions(opts);
 
         // if prefix is set to something non-zero, set it as the full config
-        // this is almost always just APP_CONFIG
         if (opts.prefix.length > 0) {
+          // this is almost always just APP_CONFIG
+          const variableName = opts.prefix;
+
           // if we specified --only FOO, don't include APP_CONFIG
-          if (!opts.only || opts.only.includes(opts.prefix)) {
-            env[opts.prefix] = stringify(fullConfig, fileTypeForFormatOption(opts.format), true);
+          if (!opts.only || opts.only.includes(variableName)) {
+            env[variableName] = stringify(fullConfig, fileTypeForFormatOption(opts.format), true);
+          }
+
+          // this is APP_CONFIG_SCHEMA, a special variable used by programs to do their own validation
+          const schemaVariableName = `${variableName}_SCHEMA`;
+
+          if (schema && (!opts.only || opts.only.includes(schemaVariableName))) {
+            env[schemaVariableName] = stringify(
+              schema as Json,
+              fileTypeForFormatOption(opts.format),
+              true,
+            );
           }
         }
 

--- a/app-config/src/cli.ts
+++ b/app-config/src/cli.ts
@@ -409,7 +409,7 @@ export const cli = yargs
 
         const [toPrint] = await loadConfigWithOptions(opts);
 
-        process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format)));
+        process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format), true));
         process.stdout.write('\n');
       },
     ),
@@ -449,7 +449,7 @@ export const cli = yargs
           toPrint = schema as Json;
         }
 
-        process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format)));
+        process.stdout.write(stringify(toPrint, fileTypeForFormatOption(opts.format), true));
         process.stdout.write('\n');
       },
     ),

--- a/app-config/src/generate.test.ts
+++ b/app-config/src/generate.test.ts
@@ -10,7 +10,7 @@ describe('TypeScript File Generation', () => {
       properties: {
         foo: { type: 'string' },
       },
-    };
+    } as const;
 
     const generated = await generateQuicktype(schema, 'ts', 'Configuration');
 
@@ -132,7 +132,7 @@ describe('Flow File Generation', () => {
       properties: {
         foo: { type: 'string' },
       },
-    };
+    } as const;
 
     const generated = await generateQuicktype(schema, 'flow', 'Configuration');
 
@@ -148,7 +148,7 @@ describe('Golang File Generation', () => {
       properties: {
         foo: { type: 'string' },
       },
-    };
+    } as const;
 
     const generated = await generateQuicktype(schema, 'go', 'Configuration');
 
@@ -164,7 +164,7 @@ describe('Rust File Generation', () => {
       properties: {
         foo: { type: 'string' },
       },
-    };
+    } as const;
 
     const generated = await generateQuicktype(schema, 'rust', 'Configuration');
 

--- a/app-config/src/generate.ts
+++ b/app-config/src/generate.ts
@@ -83,21 +83,23 @@ export async function generateQuicktype(
   const inputData = new InputData();
   await inputData.addSource('schema', src, () => new JSONSchemaInput(undefined));
 
+  if (['ts', 'typescript', 'flow'].includes(type)) {
+    Object.assign(rendererOptions, {
+      'just-types': 'true',
+      'runtime-typecheck': 'false',
+      ...rendererOptions,
+    });
+  }
+
   const { lines } = await quicktype({
     inputData,
     lang: type,
     indentation: '  ',
     leadingComments,
-    rendererOptions: ['ts', 'flow'].includes(type)
-      ? {
-          'just-types': 'true',
-          'runtime-typecheck': 'false',
-          ...rendererOptions,
-        }
-      : rendererOptions,
+    rendererOptions,
   });
 
-  if (type === 'ts') {
+  if (['ts', 'typescript'].includes(type)) {
     lines.splice(leadingComments.length, 0, '', "import '@lcdev/app-config';");
 
     // some configs are empty, so just mark them as an empty object

--- a/app-config/src/generate.ts
+++ b/app-config/src/generate.ts
@@ -7,9 +7,8 @@ import {
   JSONSchemaSourceData,
   InputData,
 } from 'quicktype-core';
-import { JsonObject } from './common';
 import { loadMetaConfig, Options as MetaOptions } from './meta';
-import { loadSchema, Options as SchemaOptions } from './schema';
+import { loadSchema, JSONSchema, Options as SchemaOptions } from './schema';
 import { logger } from './logging';
 
 export interface Options {
@@ -66,7 +65,7 @@ export async function generateTypeFiles({ directory, schemaOptions, metaOptions 
 }
 
 export async function generateQuicktype(
-  schema: JsonObject,
+  schema: JSONSchema,
   type: string,
   name: string,
   augmentModule: boolean = true,

--- a/app-config/src/schema.test.ts
+++ b/app-config/src/schema.test.ts
@@ -10,6 +10,20 @@ describe('Schema Loading', () => {
     await expect(loadSchema()).rejects.toThrow();
   });
 
+  it('loads schema from APP_CONFIG_SCHEMA variable', async () => {
+    process.env.APP_CONFIG_SCHEMA = JSON.stringify({
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    });
+
+    const { value } = await loadSchema();
+
+    expect(value).toMatchObject({
+      type: 'object',
+      properties: { foo: { type: 'string' } },
+    });
+  });
+
   it('loads a simple YAML schema', async () => {
     await withTempFiles(
       {

--- a/app-config/src/schema.ts
+++ b/app-config/src/schema.ts
@@ -1,20 +1,25 @@
 import { join, relative, resolve } from 'path';
 import Ajv from 'ajv';
-import RefParser, { bundle } from 'json-schema-ref-parser';
+import RefParser, { JSONSchema, bundle } from 'json-schema-ref-parser';
 import { JsonObject, isObject, isWindows } from './common';
 import { ParsedValue, ParsingExtension } from './parsed-value';
 import { defaultAliases, EnvironmentAliases } from './environment';
 import {
+  EnvironmentSource,
   FlexibleFileSource,
   FileSource,
   parseRawString,
   filePathAssumedType,
 } from './config-source';
-import { ValidationError, SecretsInNonSecrets, WasNotObject } from './errors';
+import { ValidationError, SecretsInNonSecrets, WasNotObject, NotFoundError } from './errors';
+import { logger } from './logging';
+
+export { JSONSchema };
 
 export interface Options {
   directory?: string;
   fileNameBase?: string;
+  environmentVariableName?: string;
   environmentOverride?: string;
   environmentAliases?: EnvironmentAliases;
   parsingExtensions?: ParsingExtension[];
@@ -23,27 +28,55 @@ export interface Options {
 export type Validate = (fullConfig: JsonObject, parsed?: ParsedValue) => void;
 
 export interface Schema {
-  value: JsonObject;
+  value: JSONSchema;
   validate: Validate;
 }
 
 export async function loadSchema({
   directory = '.',
   fileNameBase = '.app-config.schema',
+  environmentVariableName = 'APP_CONFIG_SCHEMA',
   environmentOverride,
   environmentAliases = defaultAliases,
   parsingExtensions = [],
 }: Options = {}): Promise<Schema> {
-  const source = new FlexibleFileSource(
-    join(directory, fileNameBase),
-    environmentOverride,
-    environmentAliases,
-  );
+  const env = new EnvironmentSource(environmentVariableName);
+  logger.verbose(`Trying to read ${environmentVariableName} for schema`);
 
-  const parsed = await source.read(parsingExtensions);
+  let parsed: ParsedValue | undefined;
+
+  parsed = await env.read(parsingExtensions).catch((error) => {
+    // having no APP_CONFIG_SCHEMA environment variable is normal, and should fall through to reading files
+    if (error instanceof NotFoundError) {
+      return undefined;
+    }
+
+    return Promise.reject(error);
+  });
+
+  if (!parsed) {
+    logger.verbose(`Searching for ${fileNameBase} file`);
+
+    const source = new FlexibleFileSource(
+      join(directory, fileNameBase),
+      environmentOverride,
+      environmentAliases,
+    );
+
+    parsed = await source.read(parsingExtensions);
+  }
+
   const parsedObject = parsed.toJSON();
 
   if (!isObject(parsedObject)) throw new WasNotObject('JSON Schema was not an object');
+
+  logger.verbose(
+    `Loaded schema from ${
+      parsed.getSource(FileSource)?.filePath ??
+      parsed.getSource(EnvironmentSource)?.variableName ??
+      'unknown source'
+    }`,
+  );
 
   // default to draft 07
   if (!parsedObject.$schema) {
@@ -115,10 +148,7 @@ export async function loadSchema({
   };
 }
 
-async function normalizeSchema(
-  schema: JsonObject,
-  directory: string,
-): Promise<RefParser.JSONSchema> {
+async function normalizeSchema(schema: JsonObject, directory: string): Promise<JSONSchema> {
   // NOTE: http is enabled by default
   const resolveOptions: RefParser.Options['resolve'] = {
     file: {

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -36,10 +36,9 @@ This JSON value should an object. Libraries should reject invalid JSON strings o
 
 Whether the value contained in `APP_CONFIG` is valid is up to the schema.
 
-Schemas are JSON files, with the exact name `.app-config.schema.json`.
-This file should be present in the working directory, but libraries should provide an option for this.
+Schemas are JSON values, exposed through another environment variable named `APP_CONFIG_SCHEMA`.
 
-A missing schema file should result in an error, unless the library provides a non-validation opt-out option.
+A missing schema should result in an error, unless the library provides a non-validation opt-out option.
 
 Schemas should follow the exact specification of [JSON Schema](https://json-schema.org/specification.html).
 Users tend to use draft releases of this spec, so libraries are encouraged to support as many versions as possible.
@@ -100,11 +99,11 @@ And for production to look like:
 # extract configuration for the deployment environment, and expose it as an environment variable
 APP_CONFIG=$(NODE_ENV=qa npx @lcdev/app-config -s create --format json)
 
-# normalize your development schema into a JSON file, ensuring that it's present in production
-npx @lcdev/app-config create-schema --format json > .app-config.schema.json
+# normalize your development schema, ensuring that it's present in production
+APP_CONFIG_SCHEMA=$(npx @lcdev/app-config create-schema --format json)
 ```
 
 This is a simple example, meant to show not tell. The idea is that `@lcdev/app-config`
-itself is used for creating the final values / files that your app uses. This allows
-your app to use the configuration easily without having to know about complicated
-parsing extensions, inter-file dependencies, etc.
+itself is used for creating the final values that your app uses. This allows your app
+to use the configuration easily without having to know about complicated parsing
+extensions, inter-file dependencies, etc.

--- a/examples/frontend-webpack-project/package.json
+++ b/examples/frontend-webpack-project/package.json
@@ -4,8 +4,8 @@
   "license": "MPL-2.0",
   "private": true,
   "scripts": {
-    "dev": "NODE_ENV=development webpack-dev-server",
-    "build": "NODE_ENV=production webpack --mode production",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server",
+    "build": "cross-env NODE_ENV=production webpack --mode production",
     "clean": "rm -rf ./dist",
     "lint": "exit 0",
     "fix": "exit 0",
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@lcdev/app-config-webpack-plugin": "2 || 2.0.0-rc.8",
     "@lcdev/tsconfig": "0.2",
+    "cross-env": "7",
     "html-webpack-plugin": "4",
     "ts-loader": "8",
     "typescript": "4",

--- a/examples/react-native-project/package.json
+++ b/examples/react-native-project/package.json
@@ -14,8 +14,7 @@
     "clean": "exit 0",
     "lint": "exit 0",
     "fix": "exit 0",
-    "test": "exit 0",
-    "postinstall": "expo-yarn-workspaces postinstall"
+    "test": "exit 0"
   },
   "dependencies": {
     "@lcdev/app-config": "2 || 2.0.0-rc.8",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "fix": "yarn workspaces run fix",
     "cli": "yarn --cwd ./app-config cli",
     "docs:dev": "yarn --cwd ./docs dev",
-    "docs:build": "yarn --cwd ./docs build"
+    "docs:build": "yarn --cwd ./docs build",
+    "postinstall": "cd ./examples/react-native-project && expo-yarn-workspaces postinstall"
   },
   "devDependencies": {
     "@commitlint/cli": "11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4499,6 +4499,13 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
+cross-env@7:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -4519,7 +4526,7 @@ cross-spawn@^6.0.0, cross-spawn@^6.0.5:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -8787,9 +8794,9 @@ js-base64@^2.4.3:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@3, js-yaml@^3.11.0, js-yaml@^3.13.1:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
-  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -10578,9 +10585,9 @@ opencollective-postinstall@^2.0.2:
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
 openpgp@4:
-  version "4.10.8"
-  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-4.10.8.tgz#b08d9f52ced344128cf477dc060fc233792078aa"
-  integrity sha512-l+/u3TyR3+qS7mN0+HoNQRu/2BzHdLOMOOCDRLDE9gZGAqpKkD9ZD7hkpjan+GGY3f0nHaE7Qv7kI6qmQK+AkA==
+  version "4.10.9"
+  resolved "https://registry.yarnpkg.com/openpgp/-/openpgp-4.10.9.tgz#fe61cc821fe6d9dd00036d66593b5882d50a9b1d"
+  integrity sha512-rW+q8j0wMKhXPB8s/DtLGHNWtYIgM5xElaq7RWaqQVRf9yaKMptjPq5QImG+ACpJJm6LdbN5ll/vr9Z2OWWZvg==
   dependencies:
     asn1.js "^5.0.0"
     node-fetch "^2.1.2"


### PR DESCRIPTION
This is an implementation of my idea in #50. By exposing and/or using `APP_CONFIG_SCHEMA`, we enable easier language integrations. This has other benefits as well.

- Allows in-script usage without having to write temporary schema files (instead of converting YAML -> JSON, just run the nested command and it can consume the variable)
- Makes setting up Dockerfiles way easier (no worries with ADDing schemas, cwd, etc.)
- Prototyping is also easier, just set a variable `APP_CONFIG_SCHEMA=$(app-config create-schema -f json)`
- This removes reliance on a filesystem for compliance, meaning that other implementations could be browser-only in the future

### Alternatives
This variable name overrides a top-level config property called `schema`. This, in my opinion, is fine. But we could choose a different variable name that never risks clashing (`$_APP_CONFIG_SCHEMA`, for example).

Relies on #53. Builds on #50.