### PR TITLE
Adds a $timestamp parsing extension directive

### DIFF
--- a/app-config/src/extensions.test.ts
+++ b/app-config/src/extensions.test.ts
@@ -6,6 +6,7 @@ import {
   extendsSelfDirective,
   overrideDirective,
   encryptedDirective,
+  timestampDirective,
   environmentVariableSubstitution,
 } from './extensions';
 import { generateSymmetricKey, encryptValue } from './encryption';
@@ -631,6 +632,40 @@ describe('$substitute directive', () => {
     const parsed = await source.read([environmentVariableSubstitution()]);
 
     expect(parsed.toJSON()).toEqual({ foo: 'qa' });
+  });
+});
+
+describe('$timestamp directive', () => {
+  it('uses the current date', async () => {
+    const now = new Date();
+
+    const source = new LiteralSource({
+      now: { $timestamp: true },
+    });
+
+    const parsed = await source.read([timestampDirective(() => now)]);
+
+    expect(parsed.toJSON()).toEqual({ now: now.toISOString() });
+  });
+
+  it('uses locale date string', async () => {
+    const now = new Date(2020, 11, 25, 8, 30, 0);
+
+    const source = new LiteralSource({
+      now: {
+        $timestamp: {
+          locale: 'en-US',
+          weekday: 'long',
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        },
+      },
+    });
+
+    const parsed = await source.read([timestampDirective(() => now)]);
+
+    expect(parsed.toJSON()).toEqual({ now: 'Friday, December 25, 2020' });
   });
 });
 

--- a/docs/guide/intro/extensions.md
+++ b/docs/guide/intro/extensions.md
@@ -105,6 +105,31 @@ The user will be required to unlock their keychain if the secret-agent isn't run
 password: 'enc:1:wy4ECQMI/o7E3nw9SP7g3VsIMg64HGIcRb9HyaXpQnyjozFItwx4HvsP1D2plP6Y0kYBAr2ytzs2v5bN+n2oVthkEmbrq8oqIqCF3Cx+pcjJ+5h+SyxQuJ7neNp4SRtnD4EK32rPJpyDMeHG4+pGwIjFuSH1USqQ=SZWR'
 ```
 
+## The `$timestamp` Directive
+
+Allows injecting the current date and time into configuration. While this option is useful,
+it does of course come at the cost of non-determinism.
+
+```yaml
+buildDate:
+  $timestamp: true
+```
+
+By default, this will resolve as `buildDate: new Date().toISOString()`. Options can also be passed to `toLocaleDateString()`.
+
+```yaml
+buildDate:
+  $timestamp:
+    locale: en-US
+    weekday: long
+    year: numeric
+    month: long
+    day: numeric
+```
+
+Note that the time here is entirely determined by when App Config runs. That might
+be deploy time, it might be build time, or it might be run time.
+
 ## Custom Extensions
 
 It's not all too difficult to make your own!


### PR DESCRIPTION
Provides a parsing extension to transform a `$timestamp` special directive. This helps with things like build timestamps, esp in web apps.