### PR TITLE
Adds a $git parsing extension for retrieving git status

### DIFF
--- a/app-config/package.json
+++ b/app-config/package.json
@@ -56,6 +56,7 @@
     "prompts": "2",
     "quicktype-core": "6.0.69",
     "selfsigned": "1",
+    "simple-git": "2",
     "text-encoding-utf-8": "1",
     "ws": "7",
     "yargs": "16"

--- a/app-config/src/extensions.test.ts
+++ b/app-config/src/extensions.test.ts
@@ -8,6 +8,7 @@ import {
   encryptedDirective,
   timestampDirective,
   environmentVariableSubstitution,
+  gitRefDirectives,
 } from './extensions';
 import { generateSymmetricKey, encryptValue } from './encryption';
 import { NotFoundError } from './errors';
@@ -696,6 +697,59 @@ describe('encryptedDirective', () => {
     const parsed = await source.read([encryptedDirective(symmetricKey)]);
 
     expect(parsed.toJSON()).toEqual({ foo: ['value-1', 'value-2', 'value-3'] });
+  });
+});
+
+describe('$git directive', () => {
+  it('retrieves the commit ref', async () => {
+    const source = new LiteralSource({
+      gitRef: { $git: 'commit' },
+    });
+
+    const parsed = await source.read([
+      gitRefDirectives(() =>
+        Promise.resolve({
+          commitRef: '6e96485ebf21082949c97a477b529b7a1c97a8b9',
+          branchName: 'master',
+        }),
+      ),
+    ]);
+
+    expect(parsed.toJSON()).toEqual({ gitRef: '6e96485ebf21082949c97a477b529b7a1c97a8b9' });
+  });
+
+  it('retrieves the short commit ref', async () => {
+    const source = new LiteralSource({
+      gitRef: { $git: 'commitShort' },
+    });
+
+    const parsed = await source.read([
+      gitRefDirectives(() =>
+        Promise.resolve({
+          commitRef: '6e96485ebf21082949c97a477b529b7a1c97a8b9',
+          branchName: 'master',
+        }),
+      ),
+    ]);
+
+    expect(parsed.toJSON()).toEqual({ gitRef: '6e96485' });
+  });
+
+  it('retrieves the branch name', async () => {
+    const source = new LiteralSource({
+      gitRef: { $git: 'branch' },
+    });
+
+    const parsed = await source.read([
+      gitRefDirectives(() =>
+        Promise.resolve({
+          commitRef: '6e96485ebf21082949c97a477b529b7a1c97a8b9',
+          branchName: 'master',
+        }),
+      ),
+    ]);
+
+    expect(parsed.toJSON()).toEqual({ gitRef: 'master' });
   });
 });
 

--- a/docs/guide/intro/extensions.md
+++ b/docs/guide/intro/extensions.md
@@ -130,6 +130,20 @@ buildDate:
 Note that the time here is entirely determined by when App Config runs. That might
 be deploy time, it might be build time, or it might be run time.
 
+## The `$git` Directive
+
+To retrieve the current git revision or branch name, use the `$git` directive.
+Do note that this means your config is not deterministic.
+
+```yaml
+builtRevision:
+  $git: commit # use this for the full length commit hash
+  $git: commitShort # use this for the short commit hash
+  $git: branch # use this for the current branch name
+```
+
+Note that this directive _will not fail_ if git status is not clean.
+
 ## Custom Extensions
 
 It's not all too difficult to make your own!

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,6 +1529,18 @@
   resolved "https://registry.yarnpkg.com/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@kwsites/file-exists@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/file-exists/-/file-exists-1.1.1.tgz#ad1efcac13e1987d8dbaf235ef3be5b0d96faa99"
+  integrity sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==
+  dependencies:
+    debug "^4.1.1"
+
+"@kwsites/promise-deferred@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz#8ace5259254426ccef57f3175bc64ed7095ed919"
+  integrity sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==
+
 "@lcdev/commitlint@1":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@lcdev/commitlint/-/commitlint-1.2.0.tgz#28468b83f439405d2f4145c703a4097d70374aa5"
@@ -5153,7 +5165,7 @@ debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -12776,6 +12788,15 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+
+simple-git@2:
+  version "2.31.0"
+  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-2.31.0.tgz#3e5954c1e36c76fb382c08eaa2749a206db9f613"
+  integrity sha512-/+rmE7dYZMbRAfEmn8EUIOwlM2G7UdzpkC60KF86YAfXGnmGtsPrKsym0hKvLBdFLLW019C+aZld1+6iIVy5xA==
+  dependencies:
+    "@kwsites/file-exists" "^1.1.1"
+    "@kwsites/promise-deferred" "^1.1.1"
+    debug "^4.3.1"
 
 simple-plist@^1.0.0, simple-plist@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
Allows embedding the current git revision into configuration. This is a nice feature for web apps, to show "build version" somewhere on the page. It would serve as helpful for "mismatches" as well (deploying v1 of an app, with v2 checked out locally, for example).