### PR TITLE
Upgrades internally to use ws-rpc v0.4

### DIFF
--- a/app-config/package.json
+++ b/app-config/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@iarna/toml": "3",
     "@lcdev/ts": "0.2",
-    "@lcdev/ws-rpc": "0.4.0-alpha.0",
+    "@lcdev/ws-rpc": "0.4.0-rc.1",
     "@types/openpgp": "4",
     "@types/prompts": "2",
     "@types/readable-stream": "2",

--- a/app-config/package.json
+++ b/app-config/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@iarna/toml": "3",
     "@lcdev/ts": "0.2",
-    "@lcdev/ws-rpc": "^0.3.7",
+    "@lcdev/ws-rpc": "0.4.0-alpha.0",
     "@types/openpgp": "4",
     "@types/prompts": "2",
     "@types/readable-stream": "2",

--- a/app-config/src/secret-agent.ts
+++ b/app-config/src/secret-agent.ts
@@ -65,7 +65,7 @@ export async function startAgent(portOverride?: number, privateKeyOverride?: Key
         return encoded;
       },
     })
-    .listen(new WebSocket.Server({ server: httpsServer }));
+    .listen(httpsServer);
 
   httpsServer.listen(port);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,10 +1645,10 @@
   resolved "https://registry.yarnpkg.com/@lcdev/tsconfig/-/tsconfig-0.2.0.tgz#a0fcbb2c4a83c870454ac4bf2d60cfcd8c8ab7b2"
   integrity sha512-HuFlyAfNsKVCTYZdvRyjFQPtRr9mjbm7yM7WBtqruMRDeOBMnf3fL35eTHKiN/OW8ywvkt+w0WQFEKRCDuyDFQ==
 
-"@lcdev/ws-rpc@0.4.0-alpha.0":
-  version "0.4.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@lcdev/ws-rpc/-/ws-rpc-0.4.0-alpha.0.tgz#5fc5851f731eeed50c28eaa8d61e6d6cd4373b4b"
-  integrity sha512-+nJEEiui3JQ4Mhqs/ZhFl1CSfD7wZtWEHHL+7jGD8UzZFFscxFysEInMjRMrgbdZRlhL7XNPxbjQtO1rLfuGIg==
+"@lcdev/ws-rpc@0.4.0-rc.1":
+  version "0.4.0-rc.1"
+  resolved "https://registry.yarnpkg.com/@lcdev/ws-rpc/-/ws-rpc-0.4.0-rc.1.tgz#bb4a3d80cf159e7fc78f0a3fa9cfa432d0aa6971"
+  integrity sha512-A38u7s4dLOepTM2cJ6y2bmbFSaWdOi7l3mRwcm2F0Ck4gyPi8vFEr83TuOLMP1NGKTWnYMYnc8hfY2VdLxxrVQ==
   dependencies:
     "@types/bson" "4"
     "@types/ws" "7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,10 +1645,10 @@
   resolved "https://registry.yarnpkg.com/@lcdev/tsconfig/-/tsconfig-0.2.0.tgz#a0fcbb2c4a83c870454ac4bf2d60cfcd8c8ab7b2"
   integrity sha512-HuFlyAfNsKVCTYZdvRyjFQPtRr9mjbm7yM7WBtqruMRDeOBMnf3fL35eTHKiN/OW8ywvkt+w0WQFEKRCDuyDFQ==
 
-"@lcdev/ws-rpc@^0.3.7":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/@lcdev/ws-rpc/-/ws-rpc-0.3.8.tgz#e2bac5d55429e72403191f9cacb69a3f342ef72c"
-  integrity sha512-n2kQTebLhEHrVjhVQcQ5A61JKZwIeUEO+t0bhZz9oVcysL2blGeQWfXQ78ysMYPYjG7Fx3zjQjJaQp/qZr9vwA==
+"@lcdev/ws-rpc@0.4.0-alpha.0":
+  version "0.4.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@lcdev/ws-rpc/-/ws-rpc-0.4.0-alpha.0.tgz#5fc5851f731eeed50c28eaa8d61e6d6cd4373b4b"
+  integrity sha512-+nJEEiui3JQ4Mhqs/ZhFl1CSfD7wZtWEHHL+7jGD8UzZFFscxFysEInMjRMrgbdZRlhL7XNPxbjQtO1rLfuGIg==
   dependencies:
     "@types/bson" "4"
     "@types/ws" "7"


### PR DESCRIPTION
Over the network, this should be compatible. I've done a few tests locally. The benefit here will be better built-in unix socket support for #22.

See https://www.npmjs.com/package/@lcdev/ws-rpc/v/next