### PR TITLE
Supports unix sockets for secret-agent communication

### DIFF
--- a/app-config/src/settings.ts
+++ b/app-config/src/settings.ts
@@ -13,6 +13,7 @@ export interface Settings {
     cert: string;
     expiry: string;
     port?: number;
+    socket?: string;
   };
 }
 


### PR DESCRIPTION
Uses ws-rpc built in support for `{ socket: '...' }`. Builds on #74.

Closes #22 