### PR TITLE
Adds Hashicorp Vault parsing extension support 🔒

### DIFF
--- a/app-config-vault/.eslintrc.js
+++ b/app-config-vault/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('@lcdev/eslint-config/cwd')(__dirname);

--- a/app-config-vault/README.md
+++ b/app-config-vault/README.md
@@ -3,7 +3,7 @@
 ```yaml
 $vault:
   secret: 'foo'
-  name: 'bar'
+  select: 'bar'
 ```
 
 This is like, in the CLI:

--- a/app-config-vault/README.md
+++ b/app-config-vault/README.md
@@ -1,0 +1,38 @@
+## App Config Vault Plugin
+
+```yaml
+$vault:
+  secret: 'foo'
+  name: 'bar'
+```
+
+This is like, in the CLI:
+
+```sh
+vault kv get -format=json secret/foo | jq .data.data.bar
+```
+
+Meaning, it looks up the "secret/foo", and selects the value in "bar".
+
+## Usage
+
+Install and use:
+
+```sh
+yarn add @app-config/vault
+```
+
+```typescript
+import { loadConfig, defaultExtensions } from '@lcdev/app-config';
+import vaultParsingExtension from '@app-config/vault';
+
+const vaultOptions = {
+  address: 'http://localhost:8200', // read from VAULT_ADDR if not set
+  token: '...', // read from VAULT_TOKEN if not set
+  namespace: '...', // optional, read from VAULT_NAMESPACE
+};
+
+await loadConfig({
+  parsingExtensions: defaultExtensions().concat(vaultParsingExtension(vaultOptions)),
+});
+```

--- a/app-config-vault/package.json
+++ b/app-config-vault/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@app-config/vault",
+  "description": "Hashicorp Vault support for App Config",
+  "version": "2.0.0-rc.10",
+  "license": "MPL-2.0",
+  "author": {
+    "name": "Launchcode",
+    "email": "admin@lc.dev",
+    "url": "https://lc.dev"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/launchcodedev/app-config.git"
+  },
+  "main": "dist/index.js",
+  "module": "dist/es/index.js",
+  "types": "dist/index.d.ts",
+  "files": [
+    "/dist",
+    "!*.tsbuildinfo",
+    "!*.test.*"
+  ],
+  "scripts": {
+    "build": "tsc -b",
+    "build:es": "tsc -b tsconfig.es.json",
+    "clean": "rm -rf dist *.tsbuildinfo",
+    "lint": "eslint src",
+    "fix": "eslint --fix src",
+    "test": "jest",
+    "prepublishOnly": "yarn clean && yarn build && yarn build:es"
+  },
+  "dependencies": {
+    "@lcdev/fetch": "^0.1.10",
+    "cross-fetch": "3",
+    "node-vault": "0.9"
+  },
+  "peerDependencies": {
+    "@lcdev/app-config": "2.0.0-rc.10"
+  },
+  "devDependencies": {
+    "@lcdev/app-config": "2.0.0-rc.10"
+  },
+  "prettier": "@lcdev/prettier",
+  "jest": {
+    "preset": "@lcdev/jest"
+  }
+}

--- a/app-config-vault/src/index.test.ts
+++ b/app-config-vault/src/index.test.ts
@@ -6,7 +6,7 @@ describe('vaultParsingExtension', () => {
   /*
   it('reads from vault server', async () => {
     process.env.APP_CONFIG = JSON.stringify({
-      $vault: { secret: 'foo', name: 'bar' },
+      $vault: { secret: 'foo', select: 'bar' },
     });
 
     const { fullConfig } = await loadUnvalidatedConfig({

--- a/app-config-vault/src/index.test.ts
+++ b/app-config-vault/src/index.test.ts
@@ -1,0 +1,20 @@
+describe('vaultParsingExtension', () => {
+  it('stub', () => {});
+
+  // TODO: we would need to spin up a vault server in CI for this to work
+
+  /*
+  it('reads from vault server', async () => {
+    process.env.APP_CONFIG = JSON.stringify({
+      $vault: { secret: 'foo', name: 'bar' },
+    });
+
+    const { fullConfig } = await loadUnvalidatedConfig({
+      environmentExtensions: defaultEnvExtensions().concat(vaultParsingExtension()),
+      parsingExtensions: defaultExtensions().concat(vaultParsingExtension()),
+    });
+
+    expect(fullConfig).toEqual('baz');
+  });
+  */
+});

--- a/app-config-vault/src/index.ts
+++ b/app-config-vault/src/index.ts
@@ -39,14 +39,14 @@ function vaultParsingExtension(options: Options = {}): ParsingExtension {
           throw new Error('$vault requires a an object with options');
         }
 
-        const { secret, name } = parsed;
+        const { secret, select } = parsed;
 
         if (typeof secret !== 'string') {
           throw new Error('$vault requires a "secret" option');
         }
 
-        if (typeof name !== 'string') {
-          throw new Error('$vault requires a "name" option');
+        if (typeof select !== 'string') {
+          throw new Error('$vault requires a "select" option');
         }
 
         type VaultResponse<T> = {
@@ -67,10 +67,10 @@ function vaultParsingExtension(options: Options = {}): ParsingExtension {
           .withQuery({ version: '2' })
           .json<VaultResponse<JsonObject>>();
 
-        const namedValue = data[name];
+        const namedValue = data[select];
 
         if (typeof namedValue === 'undefined') {
-          throw new Error(`The named value "${name}" was not found in the KV secret "${secret}"`);
+          throw new Error(`The named value "${select}" was not found in the KV secret "${secret}"`);
         }
 
         return parse(namedValue as Json, { shouldFlatten: true });

--- a/app-config-vault/src/index.ts
+++ b/app-config-vault/src/index.ts
@@ -1,0 +1,84 @@
+import fetch from 'cross-fetch';
+import { api, buildPath, setGlobalFetch } from '@lcdev/fetch';
+import type { JsonObject } from '@lcdev/ts';
+import type { ParsingExtension, Json } from '@lcdev/app-config';
+
+setGlobalFetch(fetch);
+
+export interface Options {
+  address?: string;
+  token?: string;
+  namespace?: string;
+}
+
+function vaultParsingExtension(options: Options = {}): ParsingExtension {
+  const address = options.address ?? process.env.VAULT_ADDR ?? 'http://127.0.0.1:8200';
+  const token = options.token ?? process.env.VAULT_TOKEN;
+  const namespace = options.namespace ?? process.env.VAULT_NAMESPACE;
+
+  const vaultApi = api(address).withTransform((builder) => {
+    let call = builder;
+
+    if (token) {
+      call = call.withHeader('X-Vault-Token', token);
+    }
+
+    if (namespace) {
+      call = call.withHeader('X-Vault-Namespace', namespace);
+    }
+
+    return call.expectStatus(200);
+  });
+
+  return (value, [_, objectKey]) => {
+    if (objectKey === '$vault') {
+      return async (parse) => {
+        const parsed = await parse(value).then((v) => v.toJSON());
+
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          throw new Error('$vault requires a an object with options');
+        }
+
+        const { secret, name } = parsed;
+
+        if (typeof secret !== 'string') {
+          throw new Error('$vault requires a "secret" option');
+        }
+
+        if (typeof name !== 'string') {
+          throw new Error('$vault requires a "name" option');
+        }
+
+        type VaultResponse<T> = {
+          data: {
+            data: T;
+          };
+          metadata: {
+            destroyed: boolean;
+          };
+        };
+
+        const path = secret.includes('/') ? secret : `secret/data/${secret}`;
+
+        const {
+          data: { data },
+        } = await vaultApi
+          .get(buildPath('v1', path))
+          .withQuery({ version: '2' })
+          .json<VaultResponse<JsonObject>>();
+
+        const namedValue = data[name];
+
+        if (typeof namedValue === 'undefined') {
+          throw new Error(`The named value "${name}" was not found in the KV secret "${secret}"`);
+        }
+
+        return parse(namedValue as Json, { shouldFlatten: true });
+      };
+    }
+
+    return false;
+  };
+}
+
+export default vaultParsingExtension;

--- a/app-config-vault/tsconfig.es.json
+++ b/app-config-vault/tsconfig.es.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "es2015",
+    "outDir": "./dist/es"
+  }
+}

--- a/app-config-vault/tsconfig.json
+++ b/app-config-vault/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@lcdev/tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "lib": ["dom"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/app-config/src/index.ts
+++ b/app-config/src/index.ts
@@ -82,7 +82,13 @@ export { loadSchema, Options as SchemaLoadingOptions } from './schema';
 export { loadMetaConfig } from './meta';
 export { setLogLevel, LogLevel } from './logging';
 export { currentEnvironment, defaultAliases } from './environment';
-export { ParsedValue, ParsedValueMetadata } from './parsed-value';
+export { Json } from './common';
+export {
+  ParsedValue,
+  ParsedValueMetadata,
+  ParsingExtension,
+  ParsingExtensionTransform,
+} from './parsed-value';
 export {
   defaultExtensions,
   defaultEnvExtensions,

--- a/new-version.sh
+++ b/new-version.sh
@@ -37,6 +37,7 @@ replace_version_references() {
 
   sed -i "s#[\"]@lcdev\\/app-config-webpack-plugin[\"]: [\"]$PREV_VERSION[\"]#\"@lcdev\\/app-config-webpack-plugin\": \"$VERSION\"#g" $@
   sed -i "s#[\"]@lcdev\\/app-config-inject[\"]: [\"]$PREV_VERSION[\"]#\"@lcdev\\/app-config-inject\": \"$VERSION\"#g" $@
+  sed -i "s#[\"]@lcdev\\/app-config-vault[\"]: [\"]$PREV_VERSION[\"]#\"@lcdev\\/app-config-vault\": \"$VERSION\"#g" $@
   sed -i "s#[\"]@lcdev\\/react-native-app-config-transformer[\"]: [\"]$PREV_VERSION[\"]#\"@lcdev\\/react-native-app-config-transformer\": \"$VERSION\"#g" $@
 
   git add $@
@@ -45,11 +46,13 @@ replace_version_references() {
 new_version ./app-config
 new_version ./app-config-webpack-plugin
 new_version ./app-config-inject
+new_version ./app-config-vault
 new_version ./app-config-react-native-transformer
 
 replace_version_references ./app-config-webpack-plugin/package.json
 replace_version_references ./app-config-inject/package.json
 replace_version_references ./app-config-react-native-transformer/package.json
+replace_version_references ./app-config-vault/package.json
 replace_version_references ./examples/*/package.json
 
 git commit -m "chore: release v$VERSION"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
       "app-config-webpack-plugin",
       "app-config-inject",
       "app-config-react-native-transformer",
+      "app-config-vault",
       "examples/*",
       "docs"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1609,6 +1609,15 @@
     eslint-plugin-react "7"
     eslint-plugin-react-hooks "4"
 
+"@lcdev/fetch@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@lcdev/fetch/-/fetch-0.1.10.tgz#a57893726422270be5ca7fdf5c17e94688e0ca1d"
+  integrity sha512-hnz6y6Njws/pPgtY++rPJJkyeLwLjACPnkPMU5vf4VvJnZ+3mFZK6P8pcs07jluiRrqD5C1XBCKTXEPB5e7/rA==
+  dependencies:
+    "@lcdev/ts" "0.2"
+    isomorphic-form-data "2"
+    query-string "6"
+
 "@lcdev/jest@0.3":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@lcdev/jest/-/jest-0.3.0.tgz#17f815154f492c2ccb22c17021dfff262bba8871"
@@ -4788,6 +4797,13 @@ cross-env@7:
   dependencies:
     cross-spawn "^7.0.1"
 
+cross-fetch@3:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -5430,6 +5446,13 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
+debug@3.1.0, debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
@@ -5443,13 +5466,6 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
   dependencies:
     ms "2.1.2"
-
-debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
 
 decamelize-keys@^1.1.0:
   version "1.1.0"
@@ -7210,6 +7226,15 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
+form-data@^2.3.2:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.1.tgz#f2cbec57b5e59e23716e128fe44d4e5dd23895f4"
+  integrity sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
+
 form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
@@ -7631,7 +7656,7 @@ har-schema@^2.0.0:
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
-har-validator@~5.1.3:
+har-validator@~5.1.0, har-validator@~5.1.3:
   version "5.1.5"
   resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
   integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
@@ -8712,6 +8737,13 @@ isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   dependencies:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
+
+isomorphic-form-data@2:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz#9f6adf1c4c61ae3aefd8f110ab60fb9b143d6cec"
+  integrity sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==
+  dependencies:
+    form-data "^2.3.2"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -10696,6 +10728,11 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+mustache@^2.2.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-2.3.2.tgz#a6d4d9c3f91d13359ab889a812954f9230a3d0c5"
+  integrity sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==
+
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
@@ -10768,6 +10805,11 @@ nocache@^2.1.0:
   resolved "https://registry.yarnpkg.com/nocache/-/nocache-2.1.0.tgz#120c9ffec43b5729b1d5de88cd71aa75a0ba491f"
   integrity sha512-0L9FvHG3nfnnmaEQPjT9xhfN4ISk0A8/2j4M37Np4mcDesJjHgEUfgPhdCyZuFI954tjokaIj/A3NdpFNdEh4Q==
 
+node-fetch@2.6.1, node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.6.0:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -10775,11 +10817,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -10860,6 +10897,17 @@ node-stream-zip@^1.9.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/node-stream-zip/-/node-stream-zip-1.12.0.tgz#f69af78799531b928662f4900d345387fa0b3777"
   integrity sha512-HZ3XehqShTFj9gHauRJ3Bri9eiCTOII7/crtXzURtT14NdnOFs9Ia5E82W7z3izVBNx760tqwddxrBJVG52Y1Q==
+
+node-vault@0.9:
+  version "0.9.20"
+  resolved "https://registry.yarnpkg.com/node-vault/-/node-vault-0.9.20.tgz#2222517bcaf4b06c3fa9abd1a2fc90ee63680a10"
+  integrity sha512-f0K/pIMgy4uRYuwBKrye6ENk5VYhp2Gjn4tUwX5ZYEIwni7dr8ZYv8td7qNx6ED+GnaLKOiKTjaV+Zn3auJWEw==
+  dependencies:
+    debug "3.1.0"
+    mustache "^2.2.1"
+    request "2.88.0"
+    request-promise-native "1.0.7"
+    tv4 "^1.2.7"
 
 noop-fn@^1.0.0:
   version "1.0.0"
@@ -12210,7 +12258,7 @@ pseudomap@^1.0.2:
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
-psl@^1.1.28:
+psl@^1.1.24, psl@^1.1.28:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.8.0.tgz#9326f8bcfb013adcc005fdff056acce020e51c24"
   integrity sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
@@ -12257,7 +12305,7 @@ punycode@1.3.2:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
   integrity sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
 
-punycode@^1.2.4, punycode@^1.3.2:
+punycode@^1.2.4, punycode@^1.3.2, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
@@ -12293,6 +12341,15 @@ qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+query-string@6:
+  version "6.13.7"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.7.tgz#af53802ff6ed56f3345f92d40a056f93681026ee"
+  integrity sha512-CsGs8ZYb39zu0WLkeOhe0NMePqgYdAuCqxOYKDR5LVCytDZYMGx3Bb+xypvQvPHVPijRXB0HZNFllCzHRe4gEA==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
 
 query-string@^5.0.1:
   version "5.1.1"
@@ -12784,12 +12841,28 @@ request-progress@^3.0.0:
   dependencies:
     throttleit "^1.0.0"
 
+request-promise-core@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.2.tgz#339f6aababcafdb31c799ff158700336301d3346"
+  integrity sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==
+  dependencies:
+    lodash "^4.17.11"
+
 request-promise-core@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
   integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
   dependencies:
     lodash "^4.17.19"
+
+request-promise-native@1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.7.tgz#a49868a624bdea5069f1251d0a836e0d89aa2c59"
+  integrity sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==
+  dependencies:
+    request-promise-core "1.1.2"
+    stealthy-require "^1.1.1"
+    tough-cookie "^2.3.3"
 
 request-promise-native@^1.0.8:
   version "1.0.9"
@@ -12799,6 +12872,32 @@ request-promise-native@^1.0.8:
     request-promise-core "1.1.4"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
+
+request@2.88.0:
+  version "2.88.0"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
+  integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
+  dependencies:
+    aws-sign2 "~0.7.0"
+    aws4 "^1.8.0"
+    caseless "~0.12.0"
+    combined-stream "~1.0.6"
+    extend "~3.0.2"
+    forever-agent "~0.6.1"
+    form-data "~2.3.2"
+    har-validator "~5.1.0"
+    http-signature "~1.2.0"
+    is-typedarray "~1.0.0"
+    isstream "~0.1.2"
+    json-stringify-safe "~5.0.1"
+    mime-types "~2.1.19"
+    oauth-sign "~0.9.0"
+    performance-now "^2.1.0"
+    qs "~6.5.2"
+    safe-buffer "^5.1.2"
+    tough-cookie "~2.4.3"
+    tunnel-agent "^0.6.0"
+    uuid "^3.3.2"
 
 request@^2.87.0, request@^2.88.2:
   version "2.88.2"
@@ -13639,6 +13738,11 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -13799,6 +13903,11 @@ strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
   integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^4.0.1:
   version "4.0.1"
@@ -14375,6 +14484,14 @@ tough-cookie@^3.0.1:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tough-cookie@~2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.4.3.tgz#53f36da3f47783b0925afa06ff9f3b165280f781"
+  integrity sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==
+  dependencies:
+    psl "^1.1.24"
+    punycode "^1.4.1"
+
 tr46@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-2.0.2.tgz#03273586def1595ae08fedb38d7733cee91d2479"
@@ -14517,6 +14634,11 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+tv4@^1.2.7:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tv4/-/tv4-1.3.0.tgz#d020c846fadd50c855abb25ebaecc68fc10f7963"
+  integrity sha1-0CDIRvrdUMhVq7JeuuzGj8EPeWM=
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
This is MVP support, although it should work with most Vault KV values. Obviously, the way to include the parsing extension right now is clunky (see #20).