### PR TITLE
Provide meta file options for `environmentAliases` and `environmentTypeNames`

### DIFF
--- a/app-config/src/config-source.ts
+++ b/app-config/src/config-source.ts
@@ -81,7 +81,7 @@ export class FlexibleFileSource extends ConfigSource {
     private readonly environmentOverride?: string,
     private readonly environmentAliases: EnvironmentAliases = defaultAliases,
     private readonly fileExtensions: string[] = ['yml', 'yaml', 'toml', 'json', 'json5'],
-    private readonly environmentTypeNames?: string[] | string,
+    private readonly environmentSourceNames?: string[] | string,
   ) {
     super();
   }
@@ -90,7 +90,7 @@ export class FlexibleFileSource extends ConfigSource {
   private async resolveSource(): Promise<FileSource> {
     const aliases = this.environmentAliases;
     const environment =
-      this.environmentOverride ?? currentEnvironment(aliases, this.environmentTypeNames);
+      this.environmentOverride ?? currentEnvironment(aliases, this.environmentSourceNames);
     const environmentAlias = Object.entries(aliases).find(([, v]) => v === environment)?.[0];
 
     const filesToTry = [];

--- a/app-config/src/config-source.ts
+++ b/app-config/src/config-source.ts
@@ -81,6 +81,7 @@ export class FlexibleFileSource extends ConfigSource {
     private readonly environmentOverride?: string,
     private readonly environmentAliases: EnvironmentAliases = defaultAliases,
     private readonly fileExtensions: string[] = ['yml', 'yaml', 'toml', 'json', 'json5'],
+    private readonly environmentTypeNames?: string[] | string,
   ) {
     super();
   }
@@ -88,7 +89,8 @@ export class FlexibleFileSource extends ConfigSource {
   // share 'resolveSource' so that read() returns a ParsedValue pointed to the FileSource, not FlexibleFileSource
   private async resolveSource(): Promise<FileSource> {
     const aliases = this.environmentAliases;
-    const environment = this.environmentOverride ?? currentEnvironment(aliases);
+    const environment =
+      this.environmentOverride ?? currentEnvironment(aliases, this.environmentTypeNames);
     const environmentAlias = Object.entries(aliases).find(([, v]) => v === environment)?.[0];
 
     const filesToTry = [];

--- a/app-config/src/config.test.ts
+++ b/app-config/src/config.test.ts
@@ -631,7 +631,7 @@ describe('Environment Aliases', () => {
         '.app-config.meta.yml': `
           environmentAliases:
             Release: production
-          environmentTypeNames:
+          environmentSourceNames:
             - CONFIGURATION
         `,
       },
@@ -646,7 +646,7 @@ describe('Environment Aliases', () => {
 });
 
 describe('Environment Variable Name', () => {
-  it('uses environmentTypeNames', async () => {
+  it('uses environmentSourceNames', async () => {
     await withTempFiles(
       {
         '.app-config.yml': `
@@ -656,7 +656,7 @@ describe('Environment Variable Name', () => {
           foo: bar-production
         `,
         '.app-config.meta.yml': `
-          environmentTypeNames: CONFIGURATION
+          environmentSourceNames: CONFIGURATION
         `,
       },
       async (inDir) => {
@@ -668,7 +668,7 @@ describe('Environment Variable Name', () => {
     );
   });
 
-  it('uses environmentTypeNames for $env', async () => {
+  it('uses environmentSourceNames for $env', async () => {
     await withTempFiles(
       {
         '.app-config.yml': `
@@ -678,7 +678,7 @@ describe('Environment Variable Name', () => {
               production: bar-production
         `,
         '.app-config.meta.yml': `
-          environmentTypeNames: CONFIGURATION
+          environmentSourceNames: CONFIGURATION
         `,
       },
       async (inDir) => {
@@ -690,7 +690,7 @@ describe('Environment Variable Name', () => {
     );
   });
 
-  it('uses array for environmentTypeNames', async () => {
+  it('uses array for environmentSourceNames', async () => {
     await withTempFiles(
       {
         '.app-config.yml': `
@@ -700,7 +700,7 @@ describe('Environment Variable Name', () => {
               production: bar-production
         `,
         '.app-config.meta.yml': `
-          environmentTypeNames:
+          environmentSourceNames:
             - CONFIGURATION
             - OTHER_ENV
         `,
@@ -714,7 +714,7 @@ describe('Environment Variable Name', () => {
     );
   });
 
-  it('uses environmentTypeNames for $APP_CONFIG_ENV substitution', async () => {
+  it('uses environmentSourceNames for $APP_CONFIG_ENV substitution', async () => {
     await withTempFiles(
       {
         '.app-config.yml': `
@@ -722,7 +722,7 @@ describe('Environment Variable Name', () => {
             $subs: $APP_CONFIG_ENV
         `,
         '.app-config.meta.yml': `
-          environmentTypeNames:
+          environmentSourceNames:
             - CONFIGURATION
         `,
       },

--- a/app-config/src/config.test.ts
+++ b/app-config/src/config.test.ts
@@ -573,3 +573,51 @@ describe('Dynamic Parsing Extension Loading', () => {
     );
   });
 });
+
+describe('Environment Aliases', () => {
+  it('uses environmentAliases as an override', async () => {
+    await withTempFiles(
+      {
+        '.app-config.yml': `
+          foo: bar-default
+        `,
+        '.app-config.production.yml': `
+          foo: bar-production
+        `,
+        '.app-config.meta.yml': `
+          environmentAliases:
+            Release: production
+        `,
+      },
+      async (inDir) => {
+        process.env.APP_CONFIG_ENV = 'Release';
+        const { fullConfig } = await loadConfig({ directory: inDir('.') });
+
+        expect(fullConfig).toEqual({ foo: 'bar-production' });
+      },
+    );
+  });
+
+  it('uses environmentAliases in $env', async () => {
+    await withTempFiles(
+      {
+        '.app-config.yml': `
+          foo:
+            $env:
+              default: bar-default
+              production: bar-production
+        `,
+        '.app-config.meta.yml': `
+          environmentAliases:
+            Release: production
+        `,
+      },
+      async (inDir) => {
+        process.env.APP_CONFIG_ENV = 'Release';
+        const { fullConfig } = await loadConfig({ directory: inDir('.') });
+
+        expect(fullConfig).toEqual({ foo: 'bar-production' });
+      },
+    );
+  });
+});

--- a/app-config/src/config.ts
+++ b/app-config/src/config.ts
@@ -17,7 +17,7 @@ export interface Options {
   extensionEnvironmentVariableNames?: string[];
   environmentOverride?: string;
   environmentAliases?: EnvironmentAliases;
-  environmentTypeNames?: string[] | string;
+  environmentSourceNames?: string[] | string;
   parsingExtensions?: ParsingExtension[];
   secretsFileExtensions?: ParsingExtension[];
   environmentExtensions?: ParsingExtension[];
@@ -47,7 +47,7 @@ export async function loadConfig({
   extensionEnvironmentVariableNames = ['APP_CONFIG_EXTEND', 'APP_CONFIG_CI'],
   environmentOverride,
   environmentAliases: environmentAliasesArg,
-  environmentTypeNames: environmentTypeNamesArg,
+  environmentSourceNames: environmentSourceNamesArg,
   parsingExtensions: parsingExtensionsArg,
   secretsFileExtensions: secretsFileExtensionsArg,
   environmentExtensions = defaultEnvExtensions(),
@@ -74,13 +74,13 @@ export async function loadConfig({
 
   const meta = await loadMetaConfig({ directory });
 
-  const environmentTypeNames = environmentTypeNamesArg ?? meta.value.environmentTypeNames;
+  const environmentSourceNames = environmentSourceNamesArg ?? meta.value.environmentSourceNames;
   const environmentAliases =
     environmentAliasesArg ?? meta.value.environmentAliases ?? defaultAliases;
 
   const parsingExtensions =
     parsingExtensionsArg ??
-    defaultExtensions(environmentAliases, environmentOverride, undefined, environmentTypeNames);
+    defaultExtensions(environmentAliases, environmentOverride, undefined, environmentSourceNames);
 
   const secretsFileExtensions =
     secretsFileExtensionsArg ?? parsingExtensions.concat(markAllValuesAsSecret());
@@ -101,7 +101,7 @@ export async function loadConfig({
       environmentOverride,
       environmentAliases,
       undefined,
-      environmentTypeNames,
+      environmentSourceNames,
     ).read(parsingExtensions),
 
     new FlexibleFileSource(
@@ -109,7 +109,7 @@ export async function loadConfig({
       environmentOverride,
       environmentAliases,
       undefined,
-      environmentTypeNames,
+      environmentSourceNames,
     )
       .read(secretsFileExtensions)
       .catch((error) => {

--- a/app-config/src/config.ts
+++ b/app-config/src/config.ts
@@ -74,24 +74,9 @@ export async function loadConfig({
 
   const meta = await loadMetaConfig({ directory });
 
-  let environmentAliases = environmentAliasesArg ?? defaultAliases;
-  let environmentTypeNames = environmentTypeNamesArg;
-
-  if (meta.value.environmentAliases) {
-    logger.verbose('Using environmentAliases override from meta file');
-
-    ({
-      value: { environmentAliases },
-    } = meta);
-  }
-
-  if (meta.value.environmentTypeNames) {
-    logger.verbose('Using environmentTypeNames override from meta file');
-
-    ({
-      value: { environmentTypeNames },
-    } = meta);
-  }
+  const environmentTypeNames = environmentTypeNamesArg ?? meta.value.environmentTypeNames;
+  const environmentAliases =
+    environmentAliasesArg ?? meta.value.environmentAliases ?? defaultAliases;
 
   const parsingExtensions =
     parsingExtensionsArg ??

--- a/app-config/src/environment.ts
+++ b/app-config/src/environment.ts
@@ -9,13 +9,13 @@ export const defaultAliases: EnvironmentAliases = {
 
 export function currentEnvironment(
   environmentAliases: EnvironmentAliases = defaultAliases,
-  environmentTypeNames: string[] | string = ['APP_CONFIG_ENV', 'NODE_ENV', 'ENV'],
+  environmentSourceNames: string[] | string = ['APP_CONFIG_ENV', 'NODE_ENV', 'ENV'],
 ) {
   let value: string | undefined;
 
-  for (const name of Array.isArray(environmentTypeNames)
-    ? environmentTypeNames
-    : [environmentTypeNames]) {
+  for (const name of Array.isArray(environmentSourceNames)
+    ? environmentSourceNames
+    : [environmentSourceNames]) {
     if (process.env[name]?.length) {
       value = process.env[name];
       break;

--- a/app-config/src/environment.ts
+++ b/app-config/src/environment.ts
@@ -7,13 +7,25 @@ export const defaultAliases: EnvironmentAliases = {
   dev: 'development',
 };
 
-export function currentEnvironment(aliases: EnvironmentAliases = defaultAliases) {
-  const value = process.env.APP_CONFIG_ENV ?? process.env.NODE_ENV ?? process.env.ENV;
+export function currentEnvironment(
+  environmentAliases: EnvironmentAliases = defaultAliases,
+  environmentTypeNames: string[] | string = ['APP_CONFIG_ENV', 'NODE_ENV', 'ENV'],
+) {
+  let value: string | undefined;
+
+  for (const name of Array.isArray(environmentTypeNames)
+    ? environmentTypeNames
+    : [environmentTypeNames]) {
+    if (process.env[name]?.length) {
+      value = process.env[name];
+      break;
+    }
+  }
 
   if (!value) return undefined;
 
-  if (aliases[value]) {
-    return aliases[value];
+  if (environmentAliases[value]) {
+    return environmentAliases[value];
   }
 
   return value;

--- a/app-config/src/extensions.ts
+++ b/app-config/src/extensions.ts
@@ -14,17 +14,18 @@ export function defaultExtensions(
   aliases: EnvironmentAliases = defaultAliases,
   environmentOverride?: string,
   symmetricKey?: DecryptedSymmetricKey,
+  environmentTypeNames?: string[] | string,
 ): ParsingExtension[] {
   return [
     v1Compat(),
-    envDirective(aliases, environmentOverride),
+    envDirective(aliases, environmentOverride, environmentTypeNames),
     extendsDirective(),
     extendsSelfDirective(),
     overrideDirective(),
     encryptedDirective(symmetricKey),
     timestampDirective(),
     unescape$Directives(),
-    environmentVariableSubstitution(aliases, environmentOverride),
+    environmentVariableSubstitution(aliases, environmentOverride, environmentTypeNames),
     gitRefDirectives(),
   ];
 }
@@ -81,8 +82,9 @@ export function extendsSelfDirective(): ParsingExtension {
 export function envDirective(
   aliases: EnvironmentAliases = defaultAliases,
   environmentOverride?: string,
+  environmentTypeNames?: string[] | string,
 ): ParsingExtension {
-  const environment = environmentOverride ?? currentEnvironment(aliases);
+  const environment = environmentOverride ?? currentEnvironment(aliases, environmentTypeNames);
   const metadata = { shouldOverride: true };
 
   return (value, [_, key]) => {
@@ -184,6 +186,7 @@ export function unescape$Directives(): ParsingExtension {
 export function environmentVariableSubstitution(
   aliases: EnvironmentAliases = defaultAliases,
   environmentOverride?: string,
+  environmentTypeNames?: string[] | string,
 ): ParsingExtension {
   const performAllSubstitutions = (text: string): string => {
     let output = text;
@@ -216,7 +219,7 @@ export function environmentVariableSubstitution(
           // we'll recurse again, so that ${FOO:-${FALLBACK}} -> ${FALLBACK} -> value
           output = performAllSubstitutions(output.replace(fullMatch, fallback));
         } else if (varName === 'APP_CONFIG_ENV') {
-          const envType = environmentOverride ?? currentEnvironment(aliases);
+          const envType = environmentOverride ?? currentEnvironment(aliases, environmentTypeNames);
 
           if (!envType) {
             throw new AppConfigError(`Could not find environment variable ${varName}`);

--- a/app-config/src/extensions.ts
+++ b/app-config/src/extensions.ts
@@ -14,18 +14,18 @@ export function defaultExtensions(
   aliases: EnvironmentAliases = defaultAliases,
   environmentOverride?: string,
   symmetricKey?: DecryptedSymmetricKey,
-  environmentTypeNames?: string[] | string,
+  environmentSourceNames?: string[] | string,
 ): ParsingExtension[] {
   return [
     v1Compat(),
-    envDirective(aliases, environmentOverride, environmentTypeNames),
+    envDirective(aliases, environmentOverride, environmentSourceNames),
     extendsDirective(),
     extendsSelfDirective(),
     overrideDirective(),
     encryptedDirective(symmetricKey),
     timestampDirective(),
     unescape$Directives(),
-    environmentVariableSubstitution(aliases, environmentOverride, environmentTypeNames),
+    environmentVariableSubstitution(aliases, environmentOverride, environmentSourceNames),
     gitRefDirectives(),
   ];
 }
@@ -82,9 +82,9 @@ export function extendsSelfDirective(): ParsingExtension {
 export function envDirective(
   aliases: EnvironmentAliases = defaultAliases,
   environmentOverride?: string,
-  environmentTypeNames?: string[] | string,
+  environmentSourceNames?: string[] | string,
 ): ParsingExtension {
-  const environment = environmentOverride ?? currentEnvironment(aliases, environmentTypeNames);
+  const environment = environmentOverride ?? currentEnvironment(aliases, environmentSourceNames);
   const metadata = { shouldOverride: true };
 
   return (value, [_, key]) => {
@@ -186,7 +186,7 @@ export function unescape$Directives(): ParsingExtension {
 export function environmentVariableSubstitution(
   aliases: EnvironmentAliases = defaultAliases,
   environmentOverride?: string,
-  environmentTypeNames?: string[] | string,
+  environmentSourceNames?: string[] | string,
 ): ParsingExtension {
   const performAllSubstitutions = (text: string): string => {
     let output = text;
@@ -219,7 +219,8 @@ export function environmentVariableSubstitution(
           // we'll recurse again, so that ${FOO:-${FALLBACK}} -> ${FALLBACK} -> value
           output = performAllSubstitutions(output.replace(fullMatch, fallback));
         } else if (varName === 'APP_CONFIG_ENV') {
-          const envType = environmentOverride ?? currentEnvironment(aliases, environmentTypeNames);
+          const envType =
+            environmentOverride ?? currentEnvironment(aliases, environmentSourceNames);
 
           if (!envType) {
             throw new AppConfigError(`Could not find environment variable ${varName}`);

--- a/app-config/src/meta.ts
+++ b/app-config/src/meta.ts
@@ -32,7 +32,7 @@ export interface MetaProperties {
   generate?: GenerateFile[];
   parsingExtensions?: (ParsingExtensionWithOptions | string)[];
   environmentAliases?: Record<string, string>;
-  environmentTypeNames?: string[] | string;
+  environmentSourceNames?: string[] | string;
 }
 
 export interface MetaConfiguration {

--- a/app-config/src/meta.ts
+++ b/app-config/src/meta.ts
@@ -32,6 +32,7 @@ export interface MetaProperties {
   generate?: GenerateFile[];
   parsingExtensions?: (ParsingExtensionWithOptions | string)[];
   environmentAliases?: Record<string, string>;
+  environmentTypeNames?: string[] | string;
 }
 
 export interface MetaConfiguration {

--- a/app-config/src/meta.ts
+++ b/app-config/src/meta.ts
@@ -31,6 +31,7 @@ export interface MetaProperties {
   encryptionKeys?: EncryptedSymmetricKey[];
   generate?: GenerateFile[];
   parsingExtensions?: (ParsingExtensionWithOptions | string)[];
+  environmentAliases?: Record<string, string>;
 }
 
 export interface MetaConfiguration {
@@ -109,14 +110,14 @@ export async function loadMetaConfigLazy(options?: Options): Promise<MetaConfigu
   return metaConfig;
 }
 
-export async function loadExtraParsingExtensions(options?: Options): Promise<ParsingExtension[]> {
-  return loadMetaConfig(options).then(({ value }) => {
-    if (value.parsingExtensions) {
-      return Promise.all(value.parsingExtensions.map(loadExtraParsingExtension));
-    }
+export async function loadExtraParsingExtensions({
+  value,
+}: MetaConfiguration): Promise<ParsingExtension[]> {
+  if (value.parsingExtensions) {
+    return Promise.all(value.parsingExtensions.map(loadExtraParsingExtension));
+  }
 
-    return Promise.resolve([]);
-  });
+  return Promise.resolve([]);
 }
 
 export async function loadExtraParsingExtension(

--- a/docs/guide/intro/settings.md
+++ b/docs/guide/intro/settings.md
@@ -11,6 +11,7 @@ Currently, the important values stored in meta files are:
 
 1. Encryption keys and team members
 2. Code generation steps
+3. Overrides for parsing and environment variable names
 
 One thing is special about meta files - if one is _not_ found in the current working directory,
 App Config will try to look at parent directories until it finds a repository root.
@@ -37,6 +38,16 @@ encryptionKeys:
   - revision: 1
     key: "-----BEGIN PGP MESSAGE-----\r\nVersion: OpenPGP.js v4.10.8\r\nComment: https://openpgpjs.org\r\n\r\nwV4DSfxLNt2seUQSAQdAcoEGyjWJhnyuopcOhwiUoCoTOfOHyitNHDcuL1OR\r\nFg4wMvZg0uINadxFkyyxRR2zYGzrzeUgkt80E0x8d8HL8F91AQFIqaQ/LJjX\r\nNns81a1W0sd7AXpmV0gr47DJwZJ1ncgeZPMqfJ0nKrmmEywy6ULbDtEMffdt\r\nt50xUnd9sTRWzDNaLkSZLGKVGi6gARfYhr81u0ryNg4yafZV/dUkbQSw2pdt\r\n/QFMvYw6rG4ccvAxNNiJazSzymg4ucwckdaAODR23PVw0vsVEDcidmDG93d/\r\na2d+CovwNUS8XprrGsQthhLJT6vx9WrpNQkfnRKYJujsH1A6v+p5ERTPPf7W\r\nIf7nWT8zAjlfF9PIapYAdqDNs8IZ012J1gWtCpXSbHIWVxU8GlkZQDqdgVeH\r\nH6TrjP9AscQJgKhV8sh5WMGEAnTAdT4dXfmV+3vKHR3Ft0K0kKy7QVkXEAzD\r\nIvr16dsR+TuJ93k+ptLz/P+Uf++I/C0h4oVD+wbKDkbe16YzpGSWLIoQdOhr\r\nN2X2XyORg3PYBbnBbCkMAGKJm5QmdDbGuQqK5o6Vt3QNTo72MyHBa+U1fuIH\r\nJQ3k1lcxrWyLMFuxCwIrH6hzwZKs+eq5W3cfiTAWyL9Hl7p7a8m8Zb/du/qY\r\n6N44dOkgZWToFE5ay9yPNdyIFJYyN0R5d4vItS7HZ7ol/vYaRvllVb0dSf6G\r\nT4GolaJkJ+LNWfBo1gslBUPvf/VDcsvygWkStzOksIxqP16U8GxZczHT+iow\r\nXogWi/+oIRENWiKIfXrTbKE8c2JXrC1bTiZ23weNqaJG33s/eTrieVhpkJUH\r\nnk3q6rWXF4VIYSCsaiVXAmAMqIak5eua2qKSsTsNEIeWVr8KdtVPD2GwdpX4\r\nUUhwhtx2UyxypD7GkIZnCexvtIMAV09zvdWLsqjpyJf63Qo0I063jB5Ik/Ho\r\nCBXsUL5Yt6RwFp0Htkibwll29jn861AIi+CVUHx9YXo3W0YnIMPayyIwAoaZ\r\nmaK6MuMM42bcmvUxZsBXaTBFChg5gGSQQCZKi2k8M/jim6pn06EciPvGQ1sq\r\nV2PPtGacg5s0fG9L5DtyrHXz8xjxQJqgyTmm9PabfwkrOizVWucH9YoiJPGq\r\nj5Zc9KY3ZR+zvZqPo7hbRLz6tfSO11birf1+jn4HRF047tTNDdTQ5cHVC7iv\r\nBV3KfZANg0pmMW7+yJtkDxlPPIGXpTwubK2eqTk1k4AGRQzMyT6S48ZsRFGP\r\nktq8EuPQx8wOrYBOKApooWEQbPpPMe+Y9RhcQvjWEqxKKkkmKC4g8oGl90ms\r\nyq3g6tiVGFOd2GnOptgaCYjGE/Utl/Itl7Gue3sIt32Yu7xRqzVGofWGN4Bw\r\nHlPaJ/GKIf3sqbRQacD5Dl8FpelAXEao7q7cUAFmsDSzi66f66S5/6hWxzHh\r\nyvQCy1F/Uzzd3AwFo5F+3tYUFPwi02GreRkHAlRf9X16+domwY/0WWLWDnRQ\r\nH8nHnmFgxopAXPg1mQkXSBUwPUikljCiQl6HkidTc3IPeaHDHo/6DRZsIu2D\r\n43mD7u1wlg2G8HUCsbLeyU1GG/T5lFr/crIv9IVlfYovddu3Wx031wSrQ2MO\r\nh/uWdPe1wpvWXI/TBu8LLnYy/RDq4TwNbf1Bc9TSQQasY/P9d/4nQhAT7P85\r\nGRbznbYKeH7WE+pQktWSqppPHutYkYHMXLGaOGLykar49lFLQO0xSqaEaymp\r\nBgT+ivgxFik2+mMOgrN/tM1oApNQd+U+yb3lq82q+WUcnuNsmk1Id76dWq8W\r\n8CLB+7kRnRrkyEVj/L1EOO9BDJG0CCz8aMyqWInQR9BJ5oRSs8b5alWxLRFj\r\nSWM144vdVlymSYSkZj5W+hkZ/xYzr3uV0udUDdN7xU+PFl+pDuGYAS9guePk\r\nAlZ2ESbIX0SBAL1ZsTZW94i0dnGvxHLvmouWLCpNOhZuRE88v17JO7aDe9DO\r\nfH0ROJJ5RzG2oR/wrnf+WyN2AreGRkZqJ/gFZkFR+DFlBO9vMNW722Ud68Sn\r\njz+tapQvWG7Wq89m3TN9/+gQRR7Cwk55QkLqBiLWZCBwaBJtUwKXBLUAbw4c\r\nAFNVx3LeQi1HgFRoN3oW/bJg+I7zlKIugRv4N504u2kwCPXoVoD121FDUtCh\r\nnASnbpoLeUzTgGFhHwKMIBYff3mR2c0d09JiQEbLtpYFKh2EEwpufVRva4wY\r\n6yPrCnBJ6rJ0JXcp5A+WW46E2boxwa1SF4pj4u9QfCrQfX8GsRqdJEHHSXSQ\r\nJStWpuSMz9dbQFAbIiUVaTFTcco/Uqgw/addYkJjmBN4XqGhcasuZq+dx+Dg\r\ntwg13xP65ckEk/SFKFM98BwHK7nGfE9o3U9xMErOMfbKGDy1pkGhXSGcfAFW\r\nkXuNzmBH4wM/yzfMx4Dt8+fx3AY//eifa3+PJPM32voGZ/Du6aQ+AmjvCP/N\r\nSKZcG+pbGDnhnbzyxmcqaTDIqxl6buT1pa1iGxjPMp0z6gO0Yhz7GWivntkC\r\nkhn64LvDYWFI1VR8RrglRDhMsOBzGyxLO4+HueMeK7eq+H8Kz78GHd22qrBQ\r\n8ZTB2l+5+D7SWz7D9Td1U+zQDGFr7HgUsvdT7/lH2hVFj4fYJsKvCG/KDJM3\r\nsoOTdAqJkNqKYq9Gq8f3SJPTQTdc20QbOp9KLFZ+43sRRUMpBJrTZdN5FrkN\r\nE6/Cq3fIsi4qJ37FjwT9Dw2e6FeJDDqYoP9s8Q6daNgpp6ZdXjNqm1XZnr8C\r\nWPF4kaNR46z0HHGDf/u5ub9m7706pJDQZrRIcI/Tg48mNIcymuoUt/FNXEBS\r\ntG4lwkz4vo/Zkd8DhMJL6TwAGRFw/fy8rkZoEh0OS+OLsgkQoBxE+bggOeLz\r\nDL1eQDiz1nS82IE1LGhEb7VU0MBwZq1TZFoKH+Z8y/GJJGcXe5dtGjkwluxr\r\nbg==\r\n=xBAf\r\n-----END PGP MESSAGE-----\r\n"
 ```
+
+## Parse and Loading Configuration
+
+The meta file can contain:
+
+- `parsingExtensions`: an array of NPM modules to load as parsing extensions ([more](./extensions.md#loading-custom-extensions))
+- `environmentAliases`: an object that maps 'aliases' to real environment names
+  - eg. `{ Release: 'production' }`
+- `environmentTypeNames`: a string or array of strings that are used an environment variable names to read for the current environment
+  - eg. `['ENV', 'NODE_ENV', 'MY_ENV']`
 
 ## App Config Settings
 

--- a/docs/guide/intro/settings.md
+++ b/docs/guide/intro/settings.md
@@ -46,7 +46,7 @@ The meta file can contain:
 - `parsingExtensions`: an array of NPM modules to load as parsing extensions ([more](./extensions.md#loading-custom-extensions))
 - `environmentAliases`: an object that maps 'aliases' to real environment names
   - eg. `{ Release: 'production' }`
-- `environmentTypeNames`: a string or array of strings that are used an environment variable names to read for the current environment
+- `environmentSourceNames`: a string or array of strings that are used an environment variable names to read for the current environment
   - eg. `['ENV', 'NODE_ENV', 'MY_ENV']`
 
 ## App Config Settings


### PR DESCRIPTION
Closes #20.

I'm not entirely happy with the name `environmentSourceNames`, but `environmentVariableName` is already used for 'APP_CONFIG'.