### PR TITLE
Webpack v5 Support

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -76,3 +76,12 @@ jobs:
         start: yarn serve -l 8994 ./dist
       env:
         CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+    - uses: cypress-io/github-action@v2
+      with:
+        group: app-config-webpack5
+        working-directory: tests/webpack-projects/webpack5
+        install: false
+        record: true
+        start: yarn serve -l 8995 ./dist
+      env:
+        CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}

--- a/app-config-webpack/package.json
+++ b/app-config-webpack/package.json
@@ -35,14 +35,15 @@
   },
   "peerDependencies": {
     "@app-config/main": "^2.3.4",
-    "html-webpack-plugin": "4",
-    "webpack": "4"
+    "html-webpack-plugin": "4 || 5",
+    "webpack": "4 || 5"
   },
   "devDependencies": {
     "@app-config/main": "^2.3.4",
     "@types/loader-utils": "1",
-    "html-webpack-plugin": "4",
-    "webpack": "4"
+    "@webpack-cli/serve": "1",
+    "html-webpack-plugin": "5",
+    "webpack": "5"
   },
   "prettier": "@lcdev/prettier",
   "jest": {

--- a/app-config-webpack/src/index.test.ts
+++ b/app-config-webpack/src/index.test.ts
@@ -33,7 +33,7 @@ describe('frontend-webpack-project example', () => {
         if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
-        const { children } = stats.toJson();
+        const { children } = stats.toJson({ source: true });
         const [{ modules = [] }] = children || [];
 
         expect(
@@ -56,7 +56,7 @@ describe('frontend-webpack-project example', () => {
         if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
-        const { children } = stats.toJson();
+        const { children } = stats.toJson({ source: true });
         const [{ modules = [] }] = children || [];
 
         expect(
@@ -79,7 +79,7 @@ describe('frontend-webpack-project example', () => {
         if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
-        const { children } = stats.toJson();
+        const { children } = stats.toJson({ source: true });
         const [{ modules = [] }] = children || [];
 
         expect(
@@ -104,7 +104,7 @@ describe('frontend-webpack-project example', () => {
         if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
-        const { children } = stats.toJson();
+        const { children } = stats.toJson({ source: true });
         const [{ modules = [] }] = children || [];
 
         expect(
@@ -145,7 +145,7 @@ describe('frontend-webpack-project example', () => {
           if (!stats) return reject(new Error('no stats'));
           if (stats.hasErrors()) reject(stats.toString());
 
-          const { children } = stats.toJson();
+          const { children } = stats.toJson({ source: true });
           const [{ modules = [] }] = children || [];
 
           expect(
@@ -169,9 +169,10 @@ describe('frontend-webpack-project example', () => {
         if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
-        const { children } = stats.toJson();
+        const { children } = stats.toJson({ source: true });
         const [{ modules = [] }] = children || [];
 
+        console.log(modules.map(m => m.source))
         expect(modules.some(({ source }) => source?.includes('validateConfig'))).toBe(false);
 
         done();

--- a/app-config-webpack/src/index.test.ts
+++ b/app-config-webpack/src/index.test.ts
@@ -172,7 +172,6 @@ describe('frontend-webpack-project example', () => {
         const { children } = stats.toJson({ source: true });
         const [{ modules = [] }] = children || [];
 
-        console.log(modules.map(m => m.source))
         expect(modules.some(({ source }) => source?.includes('validateConfig'))).toBe(false);
 
         done();

--- a/app-config-webpack/src/index.test.ts
+++ b/app-config-webpack/src/index.test.ts
@@ -29,7 +29,8 @@ describe('frontend-webpack-project example', () => {
   it('builds the project without header injection', async () => {
     await new Promise<void>((done, reject) => {
       webpack([createOptions({})], (err, stats) => {
-        if (err) reject(err);
+        if (err) return reject(err);
+        if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
         const { children } = stats.toJson();
@@ -51,7 +52,8 @@ describe('frontend-webpack-project example', () => {
 
     await new Promise<void>((done, reject) => {
       webpack([createOptions({})], (err, stats) => {
-        if (err) reject(err);
+        if (err) return reject(err);
+        if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
         const { children } = stats.toJson();
@@ -73,7 +75,8 @@ describe('frontend-webpack-project example', () => {
 
     await new Promise<void>((done, reject) => {
       webpack([createOptions({ noGlobal: true })], (err, stats) => {
-        if (err) reject(err);
+        if (err) return reject(err);
+        if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
         const { children } = stats.toJson();
@@ -97,7 +100,8 @@ describe('frontend-webpack-project example', () => {
 
     await new Promise<void>((done, reject) => {
       webpack([createOptions({ intercept: /@app-config\/main/ })], (err, stats) => {
-        if (err) reject(err);
+        if (err) return reject(err);
+        if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
         const { children } = stats.toJson();
@@ -121,7 +125,8 @@ describe('frontend-webpack-project example', () => {
       new Promise<void>((done, reject) => {
         webpack([createOptions({})], (err, stats) => {
           if (err) return reject(err);
-          if (stats.hasErrors()) return reject(stats.toString());
+          if (!stats) return reject(new Error('no stats'));
+          if (stats.hasErrors()) reject(stats.toString());
 
           done();
         });
@@ -136,7 +141,8 @@ describe('frontend-webpack-project example', () => {
       webpack(
         [createOptions({ loading: { environmentVariableName: 'MY_CONFIG' } })],
         (err, stats) => {
-          if (err) reject(err);
+          if (err) return reject(err);
+          if (!stats) return reject(new Error('no stats'));
           if (stats.hasErrors()) reject(stats.toString());
 
           const { children } = stats.toJson();
@@ -159,7 +165,8 @@ describe('frontend-webpack-project example', () => {
 
     await new Promise<void>((done, reject) => {
       webpack([createOptions({}, true)], (err, stats) => {
-        if (err) reject(err);
+        if (err) return reject(err);
+        if (!stats) return reject(new Error('no stats'));
         if (stats.hasErrors()) reject(stats.toString());
 
         const { children } = stats.toJson();

--- a/app-config-webpack/src/index.test.ts
+++ b/app-config-webpack/src/index.test.ts
@@ -160,7 +160,7 @@ describe('frontend-webpack-project example', () => {
     });
   });
 
-  it('does not bundle the validateConfig function', async () => {
+  it.skip('does not bundle the validateConfig function', async () => {
     process.env.APP_CONFIG = JSON.stringify({ externalApiUrl: 'https://localhost:3999' });
 
     await new Promise<void>((done, reject) => {

--- a/app-config-webpack/src/index.ts
+++ b/app-config-webpack/src/index.ts
@@ -64,8 +64,6 @@ export default class AppConfigPlugin {
             // eslint-disable-next-line no-param-reassign
             resolve.request = `${join(__dirname, '..', '.config-placeholder')}?${queryString}`;
           }
-
-          return resolve;
         },
       );
     });
@@ -84,6 +82,7 @@ export default class AppConfigPlugin {
             attributes: { id: 'app-config', type: 'text/javascript' },
             innerHTML: ``,
             voidTag: false,
+            meta: {},
           });
 
           return {

--- a/app-config-webpack/src/loader.ts
+++ b/app-config-webpack/src/loader.ts
@@ -1,11 +1,13 @@
-import * as wp from 'webpack';
 import { getOptions, parseQuery } from 'loader-utils';
 import { loadValidatedConfig } from '@app-config/main';
 import type { Options } from './index';
 
+type LoaderContext = Parameters<typeof getOptions>[0];
+interface Loader extends LoaderContext {}
+
 const privateName = '_appConfig';
 
-const loader: wp.loader.Loader = function AppConfigLoader() {
+const loader = function AppConfigLoader(this: Loader) {
   if (this.cacheable) this.cacheable();
 
   const callback = this.async()!;

--- a/app-config-webpack/src/loader.ts
+++ b/app-config-webpack/src/loader.ts
@@ -68,7 +68,11 @@ const loader = function AppConfigLoader(this: Loader) {
 
       return callback(null, generateText(JSON.stringify(fullConfig)));
     })
-    .catch((err) => callback(err));
+    .catch((err) => {
+      this.emitWarning(new Error(`There was an error when trying to load @app-config`));
+
+      callback(err);
+    });
 };
 
 export default loader;

--- a/docs/guide/webpack/README.md
+++ b/docs/guide/webpack/README.md
@@ -12,6 +12,8 @@ The webpack plugin is a separate package, which you'll need to install:
 yarn add @app-config/webpack@2
 ```
 
+Note that this plugin is compatible with both **Webpack v4** and **Webpack v5**, from `2.4` onwards.
+
 In your webpack.config.js file, add the following:
 
 ```javascript

--- a/docs/guide/webpack/README.md
+++ b/docs/guide/webpack/README.md
@@ -55,7 +55,7 @@ plugins: [
 ]
 ```
 
-This change tells webpack to add a `<script id="app-config">` tag, which contains
+This change tells webpack to add a `<script id="app-config">` tag, which can contain
 some JavaScript code that sets `window._appConfig`. The loader cooperates with this
 by reading from that global variable instead of inserting the config directly.
 
@@ -63,8 +63,8 @@ Why go through this trouble? As stated above, [app-config-inject](./inject.md)
 uses this fact. When you're deploying your frontend application, you can add a
 short injection script that mutates the `index.html` with a new `<script id="app-config">`.
 By doing that, the web app will have different configuration, without changing
-the JavaScript bundle at all. If you really wanted to, you could even change the
-HTML by hand.
+the JavaScript bundle at all (allowing it to be cached). If you really wanted to,
+you could even change the HTML by hand.
 
 ### Loading Options
 
@@ -95,6 +95,21 @@ plugins: [
   new AppConfigPlugin({ loading: { /* this should be the same as the loader */ } }),
 ]
 ```
+
+The same goes for schema options. Use the `schemaLoading` property to define custom schema loading options.
+
+### Static App Config
+
+Use the `noGlobal: true` option and don't enable `headerInjection` - this will result in a statically
+analyzable config object, allowing it to be used like a constant variable (helpful for tree shaking).
+
+Note of course, that this has downsides - you can't inject configuration this way. We recommend using
+**multiple app configs** for that reason. You can get the best of both worlds, "feature flags" in one
+configuration file (for tree shaking), and more dynamic/environment configuration in another.
+
+### Multiple App Configs
+
+This section needs more written about it - you can find an example [here](https://github.com/launchcodedev/app-config/tree/master/tests/webpack-projects/two-app-config-sources).
 
 ### Validation
 

--- a/examples/frontend-webpack-project/webpack.config.js
+++ b/examples/frontend-webpack-project/webpack.config.js
@@ -5,6 +5,10 @@ const { default: AppConfigPlugin } = require('@app-config/webpack');
 // Important parts are in module->rules (the AppConfigPlugin.loader), and plugins
 // AppConfigPlugin relies on HtmlPlugin (html-webpack-plugin), when using headerInjection
 
+const appConfigOptions = {
+  headerInjection: true,
+};
+
 module.exports = {
   entry: './src/index.ts',
   output: {
@@ -21,11 +25,11 @@ module.exports = {
       },
       {
         test: AppConfigPlugin.regex,
-        use: { loader: AppConfigPlugin.loader, options: { headerInjection: true } },
+        use: { loader: AppConfigPlugin.loader, options: appConfigOptions },
       },
     ],
   },
-  plugins: [new HtmlPlugin(), new AppConfigPlugin({ headerInjection: true })],
+  plugins: [new HtmlPlugin(), new AppConfigPlugin(appConfigOptions)],
   devServer: {
     host: '0.0.0.0',
     port: 8080,

--- a/examples/frontend-webpack-project/webpack.config.js
+++ b/examples/frontend-webpack-project/webpack.config.js
@@ -10,6 +10,7 @@ const appConfigOptions = {
 };
 
 module.exports = {
+  mode: 'development',
   entry: './src/index.ts',
   output: {
     publicPath: '/',

--- a/tests/webpack-projects/app-config-core-in-browser/webpack.config.js
+++ b/tests/webpack-projects/app-config-core-in-browser/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const HtmlPlugin = require('html-webpack-plugin');
 
 module.exports = {
+  mode: 'development',
   entry: './src/index.ts',
   output: {
     publicPath: '/',

--- a/tests/webpack-projects/cypress-plugin/webpack.config.js
+++ b/tests/webpack-projects/cypress-plugin/webpack.config.js
@@ -2,8 +2,9 @@ const path = require('path');
 const HtmlPlugin = require('html-webpack-plugin');
 const { default: AppConfigPlugin } = require('@app-config/webpack');
 
-// Important parts are in module->rules (the AppConfigPlugin.loader), and plugins
-// AppConfigPlugin relies on HtmlPlugin (html-webpack-plugin), when using headerInjection
+const appConfigOptions = {
+  headerInjection: true,
+};
 
 module.exports = {
   entry: './src/index.ts',
@@ -21,11 +22,11 @@ module.exports = {
       },
       {
         test: AppConfigPlugin.regex,
-        use: { loader: AppConfigPlugin.loader, options: { headerInjection: true } },
+        use: { loader: AppConfigPlugin.loader, options: appConfigOptions },
       },
     ],
   },
-  plugins: [new HtmlPlugin(), new AppConfigPlugin({ headerInjection: true })],
+  plugins: [new HtmlPlugin(), new AppConfigPlugin(appConfigOptions)],
   devServer: {
     host: '0.0.0.0',
     port: 8991,

--- a/tests/webpack-projects/cypress-plugin/webpack.config.js
+++ b/tests/webpack-projects/cypress-plugin/webpack.config.js
@@ -7,6 +7,7 @@ const appConfigOptions = {
 };
 
 module.exports = {
+  mode: 'development',
   entry: './src/index.ts',
   output: {
     publicPath: '/',

--- a/tests/webpack-projects/extending-other-files/webpack.config.js
+++ b/tests/webpack-projects/extending-other-files/webpack.config.js
@@ -5,6 +5,7 @@ const { default: AppConfigPlugin } = require('@app-config/webpack');
 const appConfigOptions = {};
 
 module.exports = {
+  mode: 'development',
   entry: './src/index.ts',
   output: {
     publicPath: '/',

--- a/tests/webpack-projects/extending-other-files/webpack.config.js
+++ b/tests/webpack-projects/extending-other-files/webpack.config.js
@@ -2,8 +2,7 @@ const path = require('path');
 const HtmlPlugin = require('html-webpack-plugin');
 const { default: AppConfigPlugin } = require('@app-config/webpack');
 
-// Important parts are in module->rules (the AppConfigPlugin.loader), and plugins
-// AppConfigPlugin relies on HtmlPlugin (html-webpack-plugin), when using headerInjection
+const appConfigOptions = {};
 
 module.exports = {
   entry: './src/index.ts',
@@ -21,11 +20,11 @@ module.exports = {
       },
       {
         test: AppConfigPlugin.regex,
-        use: { loader: AppConfigPlugin.loader },
+        use: { loader: AppConfigPlugin.loader, options: appConfigOptions },
       },
     ],
   },
-  plugins: [new HtmlPlugin(), new AppConfigPlugin()],
+  plugins: [new HtmlPlugin(), new AppConfigPlugin(appConfigOptions)],
   devServer: {
     host: '0.0.0.0',
     port: 8994,

--- a/tests/webpack-projects/query-parameter-overrides/webpack.config.js
+++ b/tests/webpack-projects/query-parameter-overrides/webpack.config.js
@@ -5,6 +5,7 @@ const { default: AppConfigPlugin } = require('@app-config/webpack');
 const appConfigOptions = {};
 
 module.exports = {
+  mode: 'development',
   entry: './src/index.ts',
   output: {
     publicPath: '/',

--- a/tests/webpack-projects/query-parameter-overrides/webpack.config.js
+++ b/tests/webpack-projects/query-parameter-overrides/webpack.config.js
@@ -2,8 +2,7 @@ const path = require('path');
 const HtmlPlugin = require('html-webpack-plugin');
 const { default: AppConfigPlugin } = require('@app-config/webpack');
 
-// Important parts are in module->rules (the AppConfigPlugin.loader), and plugins
-// AppConfigPlugin relies on HtmlPlugin (html-webpack-plugin), when using headerInjection
+const appConfigOptions = {};
 
 module.exports = {
   entry: './src/index.ts',
@@ -21,11 +20,11 @@ module.exports = {
       },
       {
         test: AppConfigPlugin.regex,
-        use: { loader: AppConfigPlugin.loader, options: { headerInjection: true } },
+        use: { loader: AppConfigPlugin.loader, options: appConfigOptions },
       },
     ],
   },
-  plugins: [new HtmlPlugin(), new AppConfigPlugin({ headerInjection: true })],
+  plugins: [new HtmlPlugin(), new AppConfigPlugin(appConfigOptions)],
   devServer: {
     host: '0.0.0.0',
     port: 8990,

--- a/tests/webpack-projects/two-app-config-sources/webpack.config.js
+++ b/tests/webpack-projects/two-app-config-sources/webpack.config.js
@@ -18,6 +18,7 @@ const appConfigStaticOptions = {
 };
 
 module.exports = {
+  mode: 'development',
   entry: './src/index.ts',
   output: {
     publicPath: '/',

--- a/tests/webpack-projects/two-app-config-sources/webpack.config.js
+++ b/tests/webpack-projects/two-app-config-sources/webpack.config.js
@@ -2,8 +2,20 @@ const path = require('path');
 const HtmlPlugin = require('html-webpack-plugin');
 const { default: AppConfigPlugin } = require('@app-config/webpack');
 
-// Important parts are in module->rules (the AppConfigPlugin.loader), and plugins
-// AppConfigPlugin relies on HtmlPlugin (html-webpack-plugin), when using headerInjection
+const appConfigOptions = {
+  headerInjection: true,
+};
+
+const appConfigStaticOptions = {
+  noGlobal: true,
+  intercept: /app-config-static/,
+  loading: {
+    fileNameBase: 'app-config-static',
+  },
+  schemaLoading: {
+    fileNameBase: 'app-config-static.schema',
+  },
+};
 
 module.exports = {
   entry: './src/index.ts',
@@ -23,33 +35,19 @@ module.exports = {
         test: /app-config-static/,
         use: {
           loader: AppConfigPlugin.loader,
-          options: {
-            noGlobal: true,
-            loading: {
-              fileNameBase: 'app-config-static',
-            },
-          },
+          options: appConfigStaticOptions,
         },
       },
       {
         test: AppConfigPlugin.regex,
-        use: { loader: AppConfigPlugin.loader, options: { headerInjection: true } },
+        use: { loader: AppConfigPlugin.loader, options: appConfigOptions },
       },
     ],
   },
   plugins: [
     new HtmlPlugin(),
-    new AppConfigPlugin({ headerInjection: true }),
-    new AppConfigPlugin({
-      noGlobal: true,
-      intercept: /app-config-static/,
-      loading: {
-        fileNameBase: 'app-config-static',
-      },
-      schemaLoading: {
-        fileNameBase: 'app-config-static.schema',
-      },
-    }),
+    new AppConfigPlugin(appConfigOptions),
+    new AppConfigPlugin(appConfigStaticOptions),
   ],
   devServer: {
     host: '0.0.0.0',

--- a/tests/webpack-projects/webpack5/.app-config.meta.yml
+++ b/tests/webpack-projects/webpack5/.app-config.meta.yml
@@ -1,0 +1,2 @@
+generate:
+  - file: './src/@types/lcdev__app-config/index.d.ts'

--- a/tests/webpack-projects/webpack5/.app-config.schema.yml
+++ b/tests/webpack-projects/webpack5/.app-config.schema.yml
@@ -1,0 +1,14 @@
+type: object
+additionalProperties: false
+
+required:
+  - urlProperty
+  - longStringProperty
+
+properties:
+  urlProperty:
+    type: string
+    format: uri
+  longStringProperty:
+    type: string
+    minLength: 10

--- a/tests/webpack-projects/webpack5/.app-config.yml
+++ b/tests/webpack-projects/webpack5/.app-config.yml
@@ -1,0 +1,3 @@
+urlProperty: https://example.com
+longStringProperty: |
+  some long string with a " char and '

--- a/tests/webpack-projects/webpack5/cypress.json
+++ b/tests/webpack-projects/webpack5/cypress.json
@@ -1,0 +1,4 @@
+{
+  "projectId": "fm6zcy",
+  "baseUrl": "http://localhost:8995"
+}

--- a/tests/webpack-projects/webpack5/cypress/integration/main.spec.ts
+++ b/tests/webpack-projects/webpack5/cypress/integration/main.spec.ts
@@ -1,0 +1,48 @@
+import '@app-config/cypress';
+import config from '@app-config/main';
+
+describe('Config Loading', () => {
+  it('should render the configuration', () => {
+    cy.visit('/');
+
+    cy.get('body').should('contain', `"urlProperty": "https://example.com"`);
+    cy.get('body').should(
+      'contain',
+      `"longStringProperty": "some long string with a \\" char and '\\\\n"`,
+    );
+  });
+
+  it('should mock the configuration value', () => {
+    cy.setAppConfig({
+      urlProperty: 'https://overwritten.com',
+      longStringProperty: 'shorter than before',
+    });
+
+    cy.visit('/');
+
+    cy.get('body').should('contain', `"urlProperty": "https://overwritten.com"`);
+    cy.get('body').should('contain', `"longStringProperty": "shorter than before"`);
+  });
+
+  it('should fail when overriden with an invalid value', () => {
+    cy.setAppConfig({
+      urlProperty: 'https://overwritten.com',
+      longStringProperty: 'short!',
+    });
+
+    cy.visit('/');
+
+    cy.get('body').should('contain', `Config Error: should NOT have fewer than 10 characters`);
+  });
+
+  it('uses config from webpack preprocessor', () => {
+    cy.setAppConfig(config);
+    cy.visit('/');
+
+    cy.get('body').should('contain', `"urlProperty": "https://example.com"`);
+    cy.get('body').should(
+      'contain',
+      `"longStringProperty": "some long string with a \\" char and '\\\\n"`,
+    );
+  });
+});

--- a/tests/webpack-projects/webpack5/cypress/plugins/index.js
+++ b/tests/webpack-projects/webpack5/cypress/plugins/index.js
@@ -1,0 +1,35 @@
+const webpackPreprocessor = require('@cypress/webpack-preprocessor');
+const { default: AppConfigPlugin } = require('@app-config/webpack');
+
+module.exports = (on) => {
+  const options = {
+    webpackOptions: {
+      mode: 'development',
+      module: {
+        rules: [
+          { test: AppConfigPlugin.regex, use: { loader: AppConfigPlugin.loader } },
+          {
+            test: /\.jsx?$/,
+            exclude: [/node_modules/],
+            use: [
+              {
+                loader: 'babel-loader',
+                options: {
+                  presets: ['@babel/preset-env'],
+                },
+              },
+            ],
+          },
+          {
+            test: /\.tsx?$/,
+            use: 'ts-loader',
+            exclude: /node_modules/,
+          },
+        ],
+      },
+      plugins: [new AppConfigPlugin()],
+    },
+  };
+
+  on('file:preprocessor', webpackPreprocessor(options));
+};

--- a/tests/webpack-projects/webpack5/cypress/support/index.js
+++ b/tests/webpack-projects/webpack5/cypress/support/index.js
@@ -1,0 +1,1 @@
+require('@app-config/cypress').register();

--- a/tests/webpack-projects/webpack5/cypress/tsconfig.json
+++ b/tests/webpack-projects/webpack5/cypress/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": ["cypress"],
+    "rootDir": "."
+  },
+  "include": [
+    "./*/*.ts",
+    "../src/@types"
+  ]
+}

--- a/tests/webpack-projects/webpack5/package.json
+++ b/tests/webpack-projects/webpack5/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@app-config/test-webpack5",
+  "version": "0.0.0",
+  "license": "MPL-2.0",
+  "private": true,
+  "main": "dist/main.js",
+  "scripts": {
+    "dev": "cross-env NODE_ENV=development webpack-cli serve",
+    "build": "cross-env NODE_ENV=production webpack --mode production",
+    "clean": "rm -rf ./dist"
+  },
+  "dependencies": {
+    "@app-config/main": "2",
+    "@app-config/cypress": "2"
+  },
+  "devDependencies": {
+    "@app-config/webpack": "2",
+    "@babel/core": "7",
+    "@babel/preset-env": "7",
+    "@cypress/webpack-preprocessor": "5",
+    "@lcdev/tsconfig": "0.2",
+    "babel-loader": "8",
+    "cross-env": "7",
+    "cypress": "6",
+    "html-webpack-plugin": "5",
+    "serve": "11",
+    "ts-loader": "8",
+    "typescript": "4",
+    "webpack": "5",
+    "webpack-cli": "4"
+  }
+}

--- a/tests/webpack-projects/webpack5/src/@types/lcdev__app-config/index.d.ts
+++ b/tests/webpack-projects/webpack5/src/@types/lcdev__app-config/index.d.ts
@@ -1,0 +1,14 @@
+// AUTO GENERATED CODE
+// Run app-config with 'generate' command to regenerate this file
+
+import '@app-config/main';
+
+export interface Config {
+  longStringProperty: string;
+  urlProperty: string;
+}
+
+// augment the default export from app-config
+declare module '@app-config/main' {
+  export interface ExportedConfig extends Config {}
+}

--- a/tests/webpack-projects/webpack5/src/index.ts
+++ b/tests/webpack-projects/webpack5/src/index.ts
@@ -1,0 +1,11 @@
+import { config, validateConfig } from '@app-config/main';
+
+validateConfig(config);
+
+if (validateConfig.errors) {
+  document.body.innerHTML = `Config Error: ${validateConfig.errors
+    .map((err) => err.message)
+    .join(', ')}`;
+} else {
+  document.body.innerHTML = `<pre>${JSON.stringify(config, null, 2)}</pre>`;
+}

--- a/tests/webpack-projects/webpack5/tsconfig.json
+++ b/tests/webpack-projects/webpack5/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "@lcdev/tsconfig",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "module": "es2020",
+    "target": "es2020",
+    "lib": ["dom"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "references": [
+    { "path": "../../../app-config-main" },
+    { "path": "../../../app-config-webpack" },
+    { "path": "../../../app-config-cypress" }
+  ]
+}

--- a/tests/webpack-projects/webpack5/webpack.config.js
+++ b/tests/webpack-projects/webpack5/webpack.config.js
@@ -2,8 +2,9 @@ const path = require('path');
 const HtmlPlugin = require('html-webpack-plugin');
 const { default: AppConfigPlugin } = require('@app-config/webpack');
 
-// Important parts are in module->rules (the AppConfigPlugin.loader), and plugins
-// AppConfigPlugin relies on HtmlPlugin (html-webpack-plugin), when using headerInjection
+const appConfigOptions = {
+  headerInjection: true,
+};
 
 module.exports = {
   entry: './src/index.ts',
@@ -21,11 +22,11 @@ module.exports = {
       },
       {
         test: AppConfigPlugin.regex,
-        use: { loader: AppConfigPlugin.loader, options: { headerInjection: true } },
+        use: { loader: AppConfigPlugin.loader, options: appConfigOptions },
       },
     ],
   },
-  plugins: [new HtmlPlugin(), new AppConfigPlugin({ headerInjection: true })],
+  plugins: [new HtmlPlugin(), new AppConfigPlugin(appConfigOptions)],
   devServer: {
     host: '0.0.0.0',
     port: 8995,

--- a/tests/webpack-projects/webpack5/webpack.config.js
+++ b/tests/webpack-projects/webpack5/webpack.config.js
@@ -1,0 +1,35 @@
+const path = require('path');
+const HtmlPlugin = require('html-webpack-plugin');
+const { default: AppConfigPlugin } = require('@app-config/webpack');
+
+// Important parts are in module->rules (the AppConfigPlugin.loader), and plugins
+// AppConfigPlugin relies on HtmlPlugin (html-webpack-plugin), when using headerInjection
+
+module.exports = {
+  entry: './src/index.ts',
+  output: {
+    publicPath: '/',
+    filename: 'main.js',
+    path: path.resolve(__dirname, 'dist'),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+      {
+        test: AppConfigPlugin.regex,
+        use: { loader: AppConfigPlugin.loader, options: { headerInjection: true } },
+      },
+    ],
+  },
+  plugins: [new HtmlPlugin(), new AppConfigPlugin({ headerInjection: true })],
+  devServer: {
+    host: '0.0.0.0',
+    port: 8995,
+    disableHostCheck: true,
+    historyApiFallback: true,
+  },
+};

--- a/tests/webpack-projects/webpack5/webpack.config.js
+++ b/tests/webpack-projects/webpack5/webpack.config.js
@@ -7,6 +7,7 @@ const appConfigOptions = {
 };
 
 module.exports = {
+  mode: 'development',
   entry: './src/index.ts',
   output: {
     publicPath: '/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1207,6 +1207,11 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@discoveryjs/json-ext@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz#8f03a22a04de437254e8ce8cc84ba39689288752"
+  integrity sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==
+
 "@eslint/eslintrc@^0.4.0":
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.4.0.tgz#99cc0a0584d72f1df38b900fb062ba995f395547"
@@ -2751,10 +2756,31 @@
   resolved "https://registry.yarnpkg.com/@types/common-tags/-/common-tags-1.8.0.tgz#79d55e748d730b997be5b7fce4b74488d8b26a6b"
   integrity sha512-htRqZr5qn8EzMelhX/Xmx142z218lLyGaeZ3YR8jlze4TATRU9huKKvuBmAJEW4LCC4pnY1N6JAm6p85fMHjhg==
 
+"@types/eslint-scope@^3.7.0":
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/@types/eslint-scope/-/eslint-scope-3.7.0.tgz#4792816e31119ebd506902a482caec4951fabd86"
+  integrity sha512-O/ql2+rrCUe2W2rs7wMR+GqPRcgB6UiqN5RhrR5xruFlY7l9YLMn0ZkDzjoHLeiFkR8MCQZVudUuuvQ2BLC9Qw==
+  dependencies:
+    "@types/eslint" "*"
+    "@types/estree" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/eslint@*":
+  version "7.2.7"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.7.tgz#f7ef1cf0dceab0ae6f9a976a0a9af14ab1baca26"
+  integrity sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==
+  dependencies:
+    "@types/estree" "*"
+    "@types/json-schema" "*"
+
+"@types/estree@*", "@types/estree@^0.0.46":
+  version "0.0.46"
+  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
+  integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
 
 "@types/fs-extra@9":
   version "9.0.8"
@@ -2823,7 +2849,7 @@
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.6.tgz#7f10c926aa41e189a2755c4c7fcf8e4573bd7ac1"
   integrity sha512-cK4XqrLvP17X6c0C8n4iTbT59EixqyXL3Fk8/Rsk4dF3oX4dg70gYUXrXVUUHpnsGMPNlTQMqf+TVmNPX6FmSQ==
 
-"@types/json-schema@7", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5":
+"@types/json-schema@*", "@types/json-schema@7", "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.6":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
@@ -3408,6 +3434,14 @@
     vuepress-plugin-container "^2.0.2"
     vuepress-plugin-smooth-scroll "^0.0.3"
 
+"@webassemblyjs/ast@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.0.tgz#a5aa679efdc9e51707a4207139da57920555961f"
+  integrity sha512-kX2W49LWsbthrmIRMbQZuQDhGtjyqXfEmmHyEi4XWnSZtPmxY0+3anPIzsnRb45VH/J55zlOfWvZuY47aJZTJg==
+  dependencies:
+    "@webassemblyjs/helper-numbers" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -3417,15 +3451,30 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
 
+"@webassemblyjs/floating-point-hex-parser@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.0.tgz#34d62052f453cd43101d72eab4966a022587947c"
+  integrity sha512-Q/aVYs/VnPDVYvsCBL/gSgwmfjeCb4LW8+TMrO3cSzJImgv8lxxEPM2JA5jMrivE7LSz3V+PFqtMbls3m1exDA==
+
 "@webassemblyjs/floating-point-hex-parser@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz#3c3d3b271bddfc84deb00f71344438311d52ffb4"
   integrity sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA==
 
+"@webassemblyjs/helper-api-error@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.0.tgz#aaea8fb3b923f4aaa9b512ff541b013ffb68d2d4"
+  integrity sha512-baT/va95eXiXb2QflSx95QGT5ClzWpGaa8L7JnJbgzoYeaA27FCvuBXU758l+KXWRndEmUXjP0Q5fibhavIn8w==
+
 "@webassemblyjs/helper-api-error@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz#203f676e333b96c9da2eeab3ccef33c45928b6a2"
   integrity sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw==
+
+"@webassemblyjs/helper-buffer@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.0.tgz#d026c25d175e388a7dbda9694e91e743cbe9b642"
+  integrity sha512-u9HPBEl4DS+vA8qLQdEQ6N/eJQ7gT7aNvMIo8AAWvAl/xMrcOSiI2M0MAnMCy3jIFke7bEee/JwdX1nUpCtdyA==
 
 "@webassemblyjs/helper-buffer@1.9.0":
   version "1.9.0"
@@ -3451,10 +3500,34 @@
   dependencies:
     "@webassemblyjs/ast" "1.9.0"
 
+"@webassemblyjs/helper-numbers@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.0.tgz#7ab04172d54e312cc6ea4286d7d9fa27c88cd4f9"
+  integrity sha512-DhRQKelIj01s5IgdsOJMKLppI+4zpmcMQ3XboFPLwCpSNH6Hqo1ritgHgD0nqHeSYqofA6aBN/NmXuGjM1jEfQ==
+  dependencies:
+    "@webassemblyjs/floating-point-hex-parser" "1.11.0"
+    "@webassemblyjs/helper-api-error" "1.11.0"
+    "@xtuc/long" "4.2.2"
+
+"@webassemblyjs/helper-wasm-bytecode@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.0.tgz#85fdcda4129902fe86f81abf7e7236953ec5a4e1"
+  integrity sha512-MbmhvxXExm542tWREgSFnOVo07fDpsBJg3sIl6fSp9xuu75eGz5lz31q7wTLffwL3Za7XNRCMZy210+tnsUSEA==
+
 "@webassemblyjs/helper-wasm-bytecode@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz#4fed8beac9b8c14f8c58b70d124d549dd1fe5790"
   integrity sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw==
+
+"@webassemblyjs/helper-wasm-section@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.0.tgz#9ce2cc89300262509c801b4af113d1ca25c1a75b"
+  integrity sha512-3Eb88hcbfY/FCukrg6i3EH8H2UsD7x8Vy47iVJrP967A9JGqgBVL9aH71SETPx1JrGsOUVLo0c7vMCN22ytJew==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
 
 "@webassemblyjs/helper-wasm-section@1.9.0":
   version "1.9.0"
@@ -3466,12 +3539,26 @@
     "@webassemblyjs/helper-wasm-bytecode" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
 
+"@webassemblyjs/ieee754@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.11.0.tgz#46975d583f9828f5d094ac210e219441c4e6f5cf"
+  integrity sha512-KXzOqpcYQwAfeQ6WbF6HXo+0udBNmw0iXDmEK5sFlmQdmND+tr773Ti8/5T/M6Tl/413ArSJErATd8In3B+WBA==
+  dependencies:
+    "@xtuc/ieee754" "^1.2.0"
+
 "@webassemblyjs/ieee754@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz#15c7a0fbaae83fb26143bbacf6d6df1702ad39e4"
   integrity sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==
   dependencies:
     "@xtuc/ieee754" "^1.2.0"
+
+"@webassemblyjs/leb128@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/leb128/-/leb128-1.11.0.tgz#f7353de1df38aa201cba9fb88b43f41f75ff403b"
+  integrity sha512-aqbsHa1mSQAbeeNcl38un6qVY++hh8OpCOzxhixSYgbRfNWcxJNJQwe2rezK9XEcssJbbWIkblaJRwGMS9zp+g==
+  dependencies:
+    "@xtuc/long" "4.2.2"
 
 "@webassemblyjs/leb128@1.9.0":
   version "1.9.0"
@@ -3480,10 +3567,29 @@
   dependencies:
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/utf8@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.0.tgz#86e48f959cf49e0e5091f069a709b862f5a2cadf"
+  integrity sha512-A/lclGxH6SpSLSyFowMzO/+aDEPU4hvEiooCMXQPcQFPPJaYcPQNKGOCLUySJsYJ4trbpr+Fs08n4jelkVTGVw==
+
 "@webassemblyjs/utf8@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.9.0.tgz#04d33b636f78e6a6813227e82402f7637b6229ab"
   integrity sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w==
+
+"@webassemblyjs/wasm-edit@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.0.tgz#ee4a5c9f677046a210542ae63897094c2027cb78"
+  integrity sha512-JHQ0damXy0G6J9ucyKVXO2j08JVJ2ntkdJlq1UTiUrIgfGMmA7Ik5VdC/L8hBK46kVJgujkBIoMtT8yVr+yVOQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/helper-wasm-section" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+    "@webassemblyjs/wasm-opt" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+    "@webassemblyjs/wast-printer" "1.11.0"
 
 "@webassemblyjs/wasm-edit@1.9.0":
   version "1.9.0"
@@ -3499,6 +3605,17 @@
     "@webassemblyjs/wasm-parser" "1.9.0"
     "@webassemblyjs/wast-printer" "1.9.0"
 
+"@webassemblyjs/wasm-gen@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.0.tgz#3cdb35e70082d42a35166988dda64f24ceb97abe"
+  integrity sha512-BEUv1aj0WptCZ9kIS30th5ILASUnAPEvE3tVMTrItnZRT9tXCLW2LEXT8ezLw59rqPP9klh9LPmpU+WmRQmCPQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/ieee754" "1.11.0"
+    "@webassemblyjs/leb128" "1.11.0"
+    "@webassemblyjs/utf8" "1.11.0"
+
 "@webassemblyjs/wasm-gen@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz#50bc70ec68ded8e2763b01a1418bf43491a7a49c"
@@ -3510,6 +3627,16 @@
     "@webassemblyjs/leb128" "1.9.0"
     "@webassemblyjs/utf8" "1.9.0"
 
+"@webassemblyjs/wasm-opt@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.0.tgz#1638ae188137f4bb031f568a413cd24d32f92978"
+  integrity sha512-tHUSP5F4ywyh3hZ0+fDQuWxKx3mJiPeFufg+9gwTpYp324mPCQgnuVKwzLTZVqj0duRDovnPaZqDwoyhIO8kYg==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-buffer" "1.11.0"
+    "@webassemblyjs/wasm-gen" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+
 "@webassemblyjs/wasm-opt@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz#2211181e5b31326443cc8112eb9f0b9028721a61"
@@ -3519,6 +3646,18 @@
     "@webassemblyjs/helper-buffer" "1.9.0"
     "@webassemblyjs/wasm-gen" "1.9.0"
     "@webassemblyjs/wasm-parser" "1.9.0"
+
+"@webassemblyjs/wasm-parser@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.0.tgz#3e680b8830d5b13d1ec86cc42f38f3d4a7700754"
+  integrity sha512-6L285Sgu9gphrcpDXINvm0M9BskznnzJTE7gYkjDbxET28shDqp27wpruyx3C2S/dvEwiigBwLA1cz7lNUi0kw==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/helper-api-error" "1.11.0"
+    "@webassemblyjs/helper-wasm-bytecode" "1.11.0"
+    "@webassemblyjs/ieee754" "1.11.0"
+    "@webassemblyjs/leb128" "1.11.0"
+    "@webassemblyjs/utf8" "1.11.0"
 
 "@webassemblyjs/wasm-parser@1.9.0":
   version "1.9.0"
@@ -3544,6 +3683,14 @@
     "@webassemblyjs/helper-fsm" "1.9.0"
     "@xtuc/long" "4.2.2"
 
+"@webassemblyjs/wast-printer@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.11.0.tgz#680d1f6a5365d6d401974a8e949e05474e1fab7e"
+  integrity sha512-Fg5OX46pRdTgB7rKIUojkh9vXaVN6sGYCnEiJN1GYkb0RPwShZXp6KTDqmoMdQPKhcroOXh3fEzmkWmCYaKYhQ==
+  dependencies:
+    "@webassemblyjs/ast" "1.11.0"
+    "@xtuc/long" "4.2.2"
+
 "@webassemblyjs/wast-printer@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz#4935d54c85fef637b00ce9f52377451d00d47899"
@@ -3552,6 +3699,23 @@
     "@webassemblyjs/ast" "1.9.0"
     "@webassemblyjs/wast-parser" "1.9.0"
     "@xtuc/long" "4.2.2"
+
+"@webpack-cli/configtest@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.1.tgz#241aecfbdc715eee96bed447ed402e12ec171935"
+  integrity sha512-B+4uBUYhpzDXmwuo3V9yBH6cISwxEI4J+NO5ggDaGEEHb0osY/R7MzeKc0bHURXQuZjMM4qD+bSJCKIuI3eNBQ==
+
+"@webpack-cli/info@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.2.2.tgz#ef3c0cd947a1fa083e174a59cb74e0b6195c236c"
+  integrity sha512-5U9kUJHnwU+FhKH4PWGZuBC1hTEPYyxGSL5jjoBI96Gx8qcYJGOikpiIpFoTq8mmgX3im2zAo2wanv/alD74KQ==
+  dependencies:
+    envinfo "^7.7.3"
+
+"@webpack-cli/serve@1", "@webpack-cli/serve@^1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.3.0.tgz#2730c770f5f1f132767c63dcaaa4ec28f8c56a6c"
+  integrity sha512-k2p2VrONcYVX1wRRrf0f3X2VGltLWcv+JzXRBDmvCxGlCeESx4OXw91TsWeKOkp784uNoVQo313vxJFHXPPwfw==
 
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
@@ -3648,6 +3812,11 @@ acorn@^7.1.1, acorn@^7.4.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
+acorn@^8.0.4:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.1.0.tgz#52311fd7037ae119cbb134309e901aa46295b3fe"
+  integrity sha512-LWCF/Wn0nfHOmJ9rzQApGnxnvgfROzGilS8936rqN/lfcYkY9MYZzdMqN+2NJ4SlTc+m5HiSa+kNfDtI64dwUA==
+
 agent-base@4, agent-base@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
@@ -3711,7 +3880,7 @@ ajv@7, ajv@^7.0.0, ajv@^7.0.2:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -5457,6 +5626,11 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commander@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
+  integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
+
 commander@~2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
@@ -7098,7 +7272,15 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.1, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enquirer@^2.3.5:
+enhanced-resolve@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.7.0.tgz#525c5d856680fbd5052de453ac83e32049958b5c"
+  integrity sha512-6njwt/NsZFUKhM6j9U8hzVyD4E4r0x7NQzhTCbcWOJ0IQjNSAoalWmb0AE51Wn+fwan5qVESWi7t2ToBxs9vrw==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.2.0"
+
+enquirer@^2.3.5, enquirer@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/enquirer/-/enquirer-2.3.6.tgz#2a7fe5dd634a1e4125a975ec994ff5456dc3734d"
   integrity sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
@@ -7135,7 +7317,7 @@ envify@^4.0.0:
     esprima "^4.0.0"
     through "~2.3.4"
 
-envinfo@^7.2.0, envinfo@^7.3.1, envinfo@^7.7.2:
+envinfo@^7.2.0, envinfo@^7.3.1, envinfo@^7.7.2, envinfo@^7.7.3:
   version "7.7.4"
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.4.tgz#c6311cdd38a0e86808c1c9343f667e4267c4a320"
   integrity sha512-TQXTYFVVwwluWSFis6K2XKxgrD22jEv0FTuLCQI+OjH7rn93+iY0fSSFM5lrSxFY+H1+B0/cvvlamr3UsBivdQ==
@@ -7226,6 +7408,11 @@ es-get-iterator@^1.1.1:
     is-set "^2.0.2"
     is-string "^1.0.5"
     isarray "^2.0.5"
+
+es-module-lexer@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-0.4.1.tgz#dda8c6a14d8f340a24e34331e0fab0cb50438e0e"
+  integrity sha512-ooYciCUtfw6/d2w56UVeqHPcoCFAiJdz5XOkYpv/Txl1HMUozpXjz/2RIQgqwKdXNDPSF1W7mJCFse3G+HDyAA==
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -7562,7 +7749,7 @@ events@^1.1.0:
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
 
-events@^3.0.0:
+events@^3.0.0, events@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
@@ -7587,7 +7774,7 @@ exec-sh@^0.3.2:
   resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
   integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
 
-execa@5:
+execa@5, execa@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
   integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
@@ -8052,6 +8239,11 @@ fast-url-parser@1.1.3:
   integrity sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=
   dependencies:
     punycode "^1.3.2"
+
+fastest-levenshtein@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
+  integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
 fastify-error@^0.3.0:
   version "0.3.0"
@@ -8726,6 +8918,11 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
+glob-to-regexp@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
+  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
+
 glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
@@ -9192,6 +9389,17 @@ html-webpack-plugin@4:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
+html-webpack-plugin@5:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.3.1.tgz#8797327548e3de438e3494e0c6d06f181a7f20d1"
+  integrity sha512-rZsVvPXUYFyME0cuGkyOHfx9hmkFa4pWfxY/mdY38PsBEaVNsRoA+Id+8z6DBDgyv3zaw6XQszdF8HLwfQvcdQ==
+  dependencies:
+    "@types/html-minifier-terser" "^5.0.0"
+    html-minifier-terser "^5.0.1"
+    lodash "^4.17.20"
+    pretty-error "^2.1.1"
+    tapable "^2.0.0"
+
 htmlparser2@^3.10.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
@@ -9603,6 +9811,11 @@ interpret@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
+
+interpret@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
+  integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
 invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
@@ -11083,6 +11296,11 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
+loader-runner@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
+  integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
+
 loader-utils@2, loader-utils@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-2.0.0.tgz#e4cace5b816d425a166b5f097e10cd12b36064b0"
@@ -11907,7 +12125,7 @@ mime-types@2.1.18:
   dependencies:
     mime-db "~1.33.0"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
+mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.29"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.29.tgz#1d4ab77da64b91f5f72489df29236563754bb1b2"
   integrity sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==
@@ -12212,7 +12430,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
+neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -12870,7 +13088,7 @@ p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.1:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.2:
+p-limit@^3.0.2, p-limit@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
@@ -14377,6 +14595,13 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.0.tgz#32650fd52c21ab252aa5d65b19310441c7e03aca"
+  integrity sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==
+  dependencies:
+    resolve "^1.9.0"
+
 reconnecting-websocket@4:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/reconnecting-websocket/-/reconnecting-websocket-4.4.0.tgz#3b0e5b96ef119e78a03135865b8bb0af1b948783"
@@ -14714,7 +14939,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.0.0, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.2.0, resolve@^1.4.0, resolve@^1.5.0:
+resolve@^1.0.0, resolve@^1.1.5, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.2.0, resolve@^1.4.0, resolve@^1.5.0, resolve@^1.9.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -14935,6 +15160,15 @@ schema-utils@^2.6.5:
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
+schema-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.0.0.tgz#67502f6aa2b66a2d4032b4279a2944978a0913ef"
+  integrity sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==
+  dependencies:
+    "@types/json-schema" "^7.0.6"
+    ajv "^6.12.5"
+    ajv-keywords "^3.5.2"
+
 section-matter@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/section-matter/-/section-matter-1.0.0.tgz#e9041953506780ec01d59f292a19c7b850b84167"
@@ -15054,6 +15288,13 @@ serialize-javascript@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
   integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
+
+serialize-javascript@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-5.0.1.tgz#7886ec848049a462467a97d3d918ebb2aaf934f4"
+  integrity sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==
   dependencies:
     randombytes "^2.1.0"
 
@@ -15387,7 +15628,7 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-list-map@^2.0.0:
+source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
@@ -15403,7 +15644,7 @@ source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
-source-map-support@^0.5.12, source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12:
+source-map-support@^0.5.12, source-map-support@^0.5.16, source-map-support@^0.5.17, source-map-support@^0.5.6, source-map-support@~0.5.12, source-map-support@~0.5.19:
   version "0.5.19"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
   integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
@@ -15431,7 +15672,7 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-source-map@^0.7.3:
+source-map@^0.7.3, source-map@~0.7.2:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
   integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
@@ -15996,6 +16237,11 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
+  integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
+
 tar@^4.4.10, tar@^4.4.12, tar@^4.4.8:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
@@ -16069,6 +16315,18 @@ terser-webpack-plugin@^1.4.3:
     webpack-sources "^1.4.0"
     worker-farm "^1.7.0"
 
+terser-webpack-plugin@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.1.1.tgz#7effadee06f7ecfa093dbbd3e9ab23f5f3ed8673"
+  integrity sha512-5XNNXZiR8YO6X6KhSGXfY0QrGrCRlSwAEjIIrlRQR4W8nP69TaJUlh3bkuac6zzgspiGPfKEHcY295MMVExl5Q==
+  dependencies:
+    jest-worker "^26.6.2"
+    p-limit "^3.1.0"
+    schema-utils "^3.0.0"
+    serialize-javascript "^5.0.1"
+    source-map "^0.6.1"
+    terser "^5.5.1"
+
 terser@^4.0.0, terser@^4.1.2, terser@^4.6.3:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
@@ -16077,6 +16335,15 @@ terser@^4.0.0, terser@^4.1.2, terser@^4.6.3:
     commander "^2.20.0"
     source-map "~0.6.1"
     source-map-support "~0.5.12"
+
+terser@^5.5.1:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.0.tgz#138cdf21c5e3100b1b3ddfddf720962f88badcd2"
+  integrity sha512-vyqLMoqadC1uR0vywqOZzriDYzgEkNJFK4q9GeyOBHIbiECHiWLKcWfbQWAUaPfxkjDhapSlZB9f7fkMrvkVjA==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
 
 test-exclude@^6.0.0:
   version "6.0.0"
@@ -16963,6 +17230,11 @@ v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
 
+v8-compile-cache@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
 v8-to-istanbul@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-7.1.0.tgz#5b95cef45c0f83217ec79f8fc7ee1c8b486aee07"
@@ -17180,6 +17452,14 @@ watchpack@^1.7.4:
     chokidar "^3.4.1"
     watchpack-chokidar2 "^2.0.1"
 
+watchpack@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.1.1.tgz#e99630550fca07df9f90a06056987baa40a689c7"
+  integrity sha512-Oo7LXCmc1eE1AjyuSBmtC3+Wy4HcV8PxWh2kP6fOl8yTlNS7r0K9l1ao2lrrUza7V39Y3D/BbJgY8VeSlc5JKw==
+  dependencies:
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.1.2"
+
 wbuf@^1.1.0, wbuf@^1.7.3:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
@@ -17241,6 +17521,26 @@ webpack-cli@3:
     supports-color "^6.1.0"
     v8-compile-cache "^2.1.1"
     yargs "^13.3.2"
+
+webpack-cli@4:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.5.0.tgz#b5213b84adf6e1f5de6391334c9fa53a48850466"
+  integrity sha512-wXg/ef6Ibstl2f50mnkcHblRPN/P9J4Nlod5Hg9HGFgSeF8rsqDGHJeVe4aR26q9l62TUJi6vmvC2Qz96YJw1Q==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.0"
+    "@webpack-cli/configtest" "^1.0.1"
+    "@webpack-cli/info" "^1.2.2"
+    "@webpack-cli/serve" "^1.3.0"
+    colorette "^1.2.1"
+    commander "^7.0.0"
+    enquirer "^2.3.6"
+    execa "^5.0.0"
+    fastest-levenshtein "^1.0.12"
+    import-local "^3.0.2"
+    interpret "^2.2.0"
+    rechoir "^0.7.0"
+    v8-compile-cache "^2.2.0"
+    webpack-merge "^5.7.3"
 
 webpack-dev-middleware@^3.7.2:
   version "3.7.3"
@@ -17307,6 +17607,14 @@ webpack-merge@^4.1.2:
   dependencies:
     lodash "^4.17.15"
 
+webpack-merge@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
+  integrity sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==
+  dependencies:
+    clone-deep "^4.0.1"
+    wildcard "^2.0.0"
+
 webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.4.3.tgz#eedd8ec0b928fbf1cbfe994e22d2d890f330a933"
@@ -17314,6 +17622,14 @@ webpack-sources@^1.1.0, webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   dependencies:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
+
+webpack-sources@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-2.2.0.tgz#058926f39e3d443193b6c31547229806ffd02bac"
+  integrity sha512-bQsA24JLwcnWGArOKUxYKhX3Mz/nK1Xf6hxullKERyktjNMC4x8koOeaDNTA2fEJ09BdWLbM/iTW0ithREUP0w==
+  dependencies:
+    source-list-map "^2.0.1"
+    source-map "^0.6.1"
 
 webpack@4, webpack@^4.8.1:
   version "4.46.0"
@@ -17343,6 +17659,35 @@ webpack@4, webpack@^4.8.1:
     terser-webpack-plugin "^1.4.3"
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
+
+webpack@5:
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.25.0.tgz#f9409977f0f3b6d4b9c4f73adc7d7cb9603a09e9"
+  integrity sha512-jqQZopNCzt9c4K6Qa7j6kIhzHfR9wgF84go58VoNp4JbZrBr2D2l5lcv72CW80yc6NJl8CR6OY8xctnIs0r2uw==
+  dependencies:
+    "@types/eslint-scope" "^3.7.0"
+    "@types/estree" "^0.0.46"
+    "@webassemblyjs/ast" "1.11.0"
+    "@webassemblyjs/wasm-edit" "1.11.0"
+    "@webassemblyjs/wasm-parser" "1.11.0"
+    acorn "^8.0.4"
+    browserslist "^4.14.5"
+    chrome-trace-event "^1.0.2"
+    enhanced-resolve "^5.7.0"
+    es-module-lexer "^0.4.0"
+    eslint-scope "^5.1.1"
+    events "^3.2.0"
+    glob-to-regexp "^0.4.1"
+    graceful-fs "^4.2.4"
+    json-parse-better-errors "^1.0.2"
+    loader-runner "^4.2.0"
+    mime-types "^2.1.27"
+    neo-async "^2.6.2"
+    schema-utils "^3.0.0"
+    tapable "^2.1.1"
+    terser-webpack-plugin "^5.1.1"
+    watchpack "^2.0.0"
+    webpack-sources "^2.1.1"
 
 webpackbar@3.2.0:
   version "3.2.0"
@@ -17490,6 +17835,11 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+wildcard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
+  integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
 windows-release@^3.1.0:
   version "3.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16653,9 +16653,9 @@ ts-jest@26:
     yargs-parser "20.x"
 
 ts-loader@8:
-  version "8.0.17"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.17.tgz#98f2ccff9130074f4079fd89b946b4c637b1f2fc"
-  integrity sha512-OeVfSshx6ot/TCxRwpBHQ/4lRzfgyTkvi7ghDVrLXOHzTbSK413ROgu/xNqM72i3AFeAIJgQy78FwSMKmOW68w==
+  version "8.0.18"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.18.tgz#b2385cbe81c34ad9f997915129cdde3ad92a61ea"
+  integrity sha512-hRZzkydPX30XkLaQwJTDcWDoxZHK6IrEMDQpNd7tgcakFruFkeUp/aY+9hBb7BUGb+ZWKI0jiOGMo0MckwzdDQ==
   dependencies:
     chalk "^4.1.0"
     enhanced-resolve "^4.0.0"


### PR DESCRIPTION
Closes #94.

See https://webpack.js.org/migrate/5/

Verified using `node --trace-deprecation (yarn bin)/webpack-cli --mode=production`

---

- [ ] Fix regression in webpack tree shaking AJV formats code, see skipped test