### PR TITLE
Add 'ac' CLI alias

### DIFF
--- a/app-config-cli/package.json
+++ b/app-config-cli/package.json
@@ -21,6 +21,7 @@
     "!**/*.test.*"
   ],
   "bin": {
+    "ac": "dist/index.js",
     "app-config": "dist/index.js",
     "app-config-secret-agent": "dist/start-secret-agent.js"
   },

--- a/app-config-main/package.json
+++ b/app-config-main/package.json
@@ -21,6 +21,7 @@
     "!**/*.test.*"
   ],
   "bin": {
+    "ac": "dist/cli.js",
     "app-config": "dist/cli.js"
   },
   "scripts": {

--- a/lcdev-app-config/package.json
+++ b/lcdev-app-config/package.json
@@ -21,6 +21,7 @@
     "!**/*.test.*"
   ],
   "bin": {
+    "ac": "dist/cli.js",
     "app-config": "dist/cli.js"
   },
   "scripts": {


### PR DESCRIPTION
Most developers at LC use `app-config` CLI via `yarn`, eg:
```bash
$ yarn app-config secret encrypt
```

It would be very convenient to have an `ac` alias to speed up CLI commands:
```bash
$ yarn ac secret encrypt
```

Or if you go all the way:
```bash
$ y ac s e
```