### PR TITLE
Fix React Native config export

### DIFF
--- a/app-config-react-native/package.json
+++ b/app-config-react-native/package.json
@@ -30,6 +30,7 @@
     "prepublishOnly": "yarn clean && yarn build && yarn build:es"
   },
   "dependencies": {
+    "@app-config/node": "^2.6.1",
     "semver": "7"
   },
   "peerDependencies": {

--- a/app-config-react-native/src/index.ts
+++ b/app-config-react-native/src/index.ts
@@ -1,4 +1,5 @@
 import { loadValidatedConfig } from '@app-config/main';
+import { currentEnvironment } from '@app-config/node';
 import { relative } from 'path';
 import { Transformer, upstreamTransformer } from './upstream-transformer';
 
@@ -23,7 +24,26 @@ export const transform: Transformer['transform'] = async ({ src, filename, optio
   // Parse config and overwrite app-config's entry point with exported config JSON
   const { fullConfig } = await loadValidatedConfig();
 
-  const modifiedSrc = `module.exports = ${JSON.stringify(fullConfig)};`;
+  const modifiedSrc = generateSrc(JSON.stringify(fullConfig));
 
   return upstreamTransformer.transform({ src: modifiedSrc, filename, options });
+};
+
+const generateSrc = (config: string) => {
+  let generatedText: string;
+
+  generatedText = `
+    const config = ${config};
+
+    export { config };
+    export default config;
+  `;
+
+  generatedText = `${generatedText}
+    export function currentEnvironment() {
+      return ${JSON.stringify(currentEnvironment()) ?? 'undefined'};
+    }
+  `;
+
+  return generatedText;
 };

--- a/examples/react-native-project/src/App.tsx
+++ b/examples/react-native-project/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import config from '@app-config/main';
+import { config } from '@app-config/main';
 import { StyleSheet, Text, View } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 
@@ -27,5 +27,5 @@ const styles = StyleSheet.create({
     fontSize: 40,
     marginBottom: 20,
     fontWeight: '700',
-  }
+  },
 });


### PR DESCRIPTION
# Problem
As of v2, app-config lets you import config as a non-default export:
```typescript
import { config } from '@app-config/main';
```

Currently the RN plugin only supports importing config from a default export.
```typescript
import config from '@app-config/main';
```

# Solution
Modify the RN Metro loader to closer match the behaviour of `@app-config/webpack` by supporting the non-default `config` export as well as the `currentEnvironment()` function.