### PR TITLE
Fix global environment override not being used by $extends

### DIFF
--- a/app-config-extensions/src/extends-directive.test.ts
+++ b/app-config-extensions/src/extends-directive.test.ts
@@ -45,6 +45,23 @@ describe('$extends directive', () => {
     );
   });
 
+  it('merges two files with env in extends file and global env override', async () => {
+    await withTempFiles(
+      {
+        'referenced-file.json': `{ "foo": { "$env": { "prod": true, "qa": false } } }`,
+        'test-file.json': `{ "$extends": "./referenced-file.json", "bar": true }`,
+      },
+      async (inDir) => {
+        const source = new FileSource(inDir('test-file.json'));
+        const parsed = await source.read([extendsDirective(), envDirective()], {
+          environmentOptions: { override: 'prod' },
+        });
+
+        expect(parsed.toJSON()).toEqual({ foo: true, bar: true });
+      },
+    );
+  });
+
   it('merges many files (flat)', async () => {
     await withTempFiles(
       {

--- a/app-config-extensions/src/extends-directive.ts
+++ b/app-config-extensions/src/extends-directive.ts
@@ -48,8 +48,11 @@ function fileReferenceDirective(keyName: string, meta: ParsedValueMetadata): Par
 
           const environmentOptions = {
             ...environmentOptionsFromContext(context),
-            override: env,
           };
+
+          if (env) {
+            environmentOptions.override = env;
+          }
 
           const parsed = await resolvedSource
             .read(extensions, {


### PR DESCRIPTION
Currently we're setting the environment to use when loading the $extends file to whatever is given in the $extends directive, even when it's undefined. This results in the wrong or no environment being used when loading the $extends file