### PR TITLE
Fix missing 'loadConfig' export error when bundling.

### DIFF
--- a/app-config-utils/package.json
+++ b/app-config-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@app-config/utils",
   "description": "Common utilities used in @app-config",
-  "version": "2.8.7",
+  "version": "2.9.0",
   "license": "MPL-2.0",
   "author": {
     "name": "Launchcode",

--- a/app-config-utils/src/index.ts
+++ b/app-config-utils/src/index.ts
@@ -58,7 +58,11 @@ export function generateModuleText(
         throw new Error('Config is not loaded in ${privateName}');
       }
 
-      export { config };
+      function loadConfig() {
+        return new Promise(resolve => {resolve(config)})
+      }
+
+      export { config, loadConfig };
       export default config;
     `;
   } else if (useGlobalNamespace) {
@@ -80,7 +84,11 @@ export function generateModuleText(
         globalNamespace.${privateName} = config;
       }
 
-      export { config };
+      function loadConfig() {
+        return new Promise(resolve => {resolve(config)})
+      }
+
+      export { config, loadConfig };
       export default config;
     `;
   } else {
@@ -89,7 +97,11 @@ export function generateModuleText(
     generatedText += `
       const config = ${config};
 
-      export { config };
+      function loadConfig() {
+        return new Promise(resolve => {resolve(config)})
+      }
+
+      export { config, loadConfig };
       export default config;
     `;
   }


### PR DESCRIPTION
Fix module generated code when using esbuild/etc plugins to allow for using 'loadConfig' in bundled environments.